### PR TITLE
chore: unify blog tags to English and merge duplicates

### DIFF
--- a/source/_posts/a-brief-break-to-go-the-distance.md
+++ b/source/_posts/a-brief-break-to-go-the-distance.md
@@ -5,7 +5,7 @@ categories: Life
 tags:
   - Korea
   - Seoul
-  - Thinking
+  - Independent Thinking
 ---
 
 每周六早上都要送儿子去 Banpo 运动场去练习足球，最近因为 Winter Break 放了两周假，足球都没碰过，我想大概是荒废了。休假的时候还想着，这荒废的两周把之前的努力都给抵消掉了。家乡有句老话「三天不打鸟，牯牛都射不倒」，所以我心里其实已经有了预期：一上场又会暴露一堆毛病。

--- a/source/_posts/ai-as-thinking-partner.md
+++ b/source/_posts/ai-as-thinking-partner.md
@@ -5,7 +5,7 @@ categories:
   - Independent Thinking
 tags:
   - AI
-  - Thinking
+  - Independent Thinking
   - Self-Reflection
   - Claude
 ---

--- a/source/_posts/ai-investment-roi-reality-check.md
+++ b/source/_posts/ai-investment-roi-reality-check.md
@@ -5,7 +5,7 @@ categories:
   - Independent Thinking
 tags:
   - AI
-  - Investment
+  - Investing
   - ROI
   - Big Tech
   - Infrastructure

--- a/source/_posts/an-email-to-my-boss.md
+++ b/source/_posts/an-email-to-my-boss.md
@@ -3,7 +3,7 @@ title: 一封写给老板的邮件
 categories:
   - Independent Thinking
 tags:
-  - 独立思考
+  - Independent Thinking
 date: 2024-01-07 07:00:00
 ---
 

--- a/source/_posts/booster-architecture.md
+++ b/source/_posts/booster-architecture.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-12-30 01:34:11
 ---
 

--- a/source/_posts/booster-assets-deduplication.md
+++ b/source/_posts/booster-assets-deduplication.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-06-22 20:00:00
 ---
 

--- a/source/_posts/booster-gradle-plugin.md
+++ b/source/_posts/booster-gradle-plugin.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-06-04 20:00:00
 ---
 

--- a/source/_posts/booster-prevent-system-from-crash.md
+++ b/source/_posts/booster-prevent-system-from-crash.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-07-02 20:16:35
 ---
 

--- a/source/_posts/booster-roadmap-2020.md
+++ b/source/_posts/booster-roadmap-2020.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-12-24 23:18:42
 ---
 

--- a/source/_posts/booster-task-analyser.md
+++ b/source/_posts/booster-task-analyser.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2020-03-21 00:00:00
 ---
 

--- a/source/_posts/booster-transform-lint.md
+++ b/source/_posts/booster-transform-lint.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-06-05 20:00:00
 ---
 

--- a/source/_posts/booster-transform-shared-preferences.md
+++ b/source/_posts/booster-transform-shared-preferences.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-11-12 21:00:00
 ---
 

--- a/source/_posts/booster-transform-thread.md
+++ b/source/_posts/booster-transform-thread.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-06-09 20:00:00
 ---
 

--- a/source/_posts/booster-xml-layout-to-code.md
+++ b/source/_posts/booster-xml-layout-to-code.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-07-13 20:00:00
 ---
 

--- a/source/_posts/booster-xml-layout-transpiler.md
+++ b/source/_posts/booster-xml-layout-transpiler.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
 date: 2019-10-30 21:00:00
 ---
 

--- a/source/_posts/circle-the-fed-on-chain.md
+++ b/source/_posts/circle-the-fed-on-chain.md
@@ -1,7 +1,7 @@
 ---
 title: Circle - 链上的美联储
 categories:
-  - Investment
+  - Investing
 tags:
   - Stock
 date: 2025-06-23 22:00:00

--- a/source/_posts/days-are-like-years.md
+++ b/source/_posts/days-are-like-years.md
@@ -3,8 +3,8 @@ title: 度日如年与度日如年
 categories:
   - Life
 tags:
-  - 职场
-  - 独立思考
+  - Career
+  - Independent Thinking
 date: 2021-09-20 02:00:00
 ---
 

--- a/source/_posts/education-for-independent-thought.md
+++ b/source/_posts/education-for-independent-thought.md
@@ -3,7 +3,7 @@ title: 培养独立思考的教育
 categories:
   - Independent Thinking
 tags:
-  - 独立思考
+  - Independent Thinking
 date: 2022-11-28 00:00:00
 ---
 

--- a/source/_posts/education-in-the-age-of-ai.md
+++ b/source/_posts/education-in-the-age-of-ai.md
@@ -3,7 +3,7 @@ title: AI 时代的教育
 categories:
   - Independent Thinking
 tags:
-  - 教育
+  - Education
 date: 2025-12-06 12:00:00
 ---
 

--- a/source/_posts/engineer-growth.md
+++ b/source/_posts/engineer-growth.md
@@ -3,7 +3,7 @@ title: 工程师如何成长
 categories:
   - Career
 tags:
-  - 职场
+  - Career
 date: 2020-08-09 02:00:00
 ---
 

--- a/source/_posts/exploring-claude-boundaries.md
+++ b/source/_posts/exploring-claude-boundaries.md
@@ -6,7 +6,7 @@ categories:
 tags:
   - AI
   - Claude
-  - Thinking
+  - Independent Thinking
 ---
 
 自从用 Claude 完成了 [Graphite](https://github.com/johnsonlee/graphite) -- 基于 JVM 字节码的静态分析框架，工程质量和解决问题的方法和效率着实把我给震撼到了，然后又让它用 Rust 写了 [Rustyman](https://github.com/johnsonlee/rustyman) -- 面向 AI 的网络代理服务，效果也很是出奇的好，名副其实的 10x 工程师。于是，便产生了一个大胆的想法 -- [TestPilot](https://github.com/johnsonlee/testpilot)，在纯 JVM 上运行 Android APK 。拿到需求后，它便进入了 Plan 模式，根据对需求的理解提出了双层架构的方案，然后规划了 Road Map，分了 3 个阶段来进行，从 Phase 1 - MVP 到 Phase 3 - Production Ready。在 MVP 阶段表现跟前两个项目一样丝滑，到了 Phase 2 一开始风风火火的重写各种 Android 系统类，也没觉得有什么不对，逐步完了 Activity, View, Fragment, ViewPager, RecyclerView 的重写，接下来它提出要重写 ConstraintLayout 的时候，我意识到不对劲了-- 重写系统类我能理解，但为什么要重写一个二方库？ConstraintLayout 并不属于 Android Framework？于是便跟它一起仔细地 review 了整个方案，才发现它对底层依赖的 layoutlib 的能力不太了解，才提出重写系统类的方案，这不禁让我开始思考一个问题：**Claude 的能力边界到底在哪里？**

--- a/source/_posts/from-llm-to-effective-communication.md
+++ b/source/_posts/from-llm-to-effective-communication.md
@@ -6,9 +6,9 @@ categories:
 tags:
   - LLM
   - Communication
-  - Thinking
+  - Independent Thinking
   - AI
-  - 教育
+  - Education
 ---
 
 最近在给儿子讲 LLM 的工作原理，做了一套 [PPT](https://llm.johnsonlee.io/) 。讲到 context window 的时候，我随手举了个例子：

--- a/source/_posts/interest-is-not-the-best-teacher.md
+++ b/source/_posts/interest-is-not-the-best-teacher.md
@@ -3,7 +3,7 @@ title: 兴趣不是最好的老师
 categories:
   - Independent Thinking
 tags:
-  - 独立思考
+  - Independent Thinking
 date: 2020-10-07 00:00:00
 ---
 

--- a/source/_posts/lost-youth.md
+++ b/source/_posts/lost-youth.md
@@ -3,7 +3,7 @@ title: 翩翩少年
 categories:
   - Life
 tags:
-  - 音乐
+  - Music
 date: 2021-08-09 00:00:00
 ---
 

--- a/source/_posts/memory-of-arch-team.md
+++ b/source/_posts/memory-of-arch-team.md
@@ -3,7 +3,7 @@ title: 架构 Team 往事
 categories:
   - Life
 tags:
-  - 职场
+  - Career
 date: 2020-09-20 02:00:00
 ---
 

--- a/source/_posts/mentor-in-the-age-of-ai.md
+++ b/source/_posts/mentor-in-the-age-of-ai.md
@@ -3,7 +3,7 @@ title: AI 时代的 Mentor
 categories:
   - Independent Thinking
 tags:
-  - 教育
+  - Education
 date: 2026-01-01 01:00:00
 ---
 

--- a/source/_posts/my-2020-review.md
+++ b/source/_posts/my-2020-review.md
@@ -3,8 +3,8 @@ title: 回顾 2020 年
 categories:
   - Career
 tags:
-  - 职场
-  - 独立思考
+  - Career
+  - Independent Thinking
 date: 2021-02-06 00:00:00
 ---
 

--- a/source/_posts/no-time-to-think-from-bottom-fishing-google-tesla-to-going-all-in-on-circle.md
+++ b/source/_posts/no-time-to-think-from-bottom-fishing-google-tesla-to-going-all-in-on-circle.md
@@ -1,7 +1,7 @@
 ---
 title: 无暇思考：从抄底 Google/Tesla 到 All in Circle
 categories:
-  - Investment
+  - Investing
 tags:
   - Stock
 date: 2025-06-21 16:00:00

--- a/source/_posts/old-friends-and-stories.md
+++ b/source/_posts/old-friends-and-stories.md
@@ -3,7 +3,7 @@ title: 重温《故人故事》
 categories:
   - Life
 tags:
-  - 独立思考
+  - Independent Thinking
 date: 2021-02-14 00:00:00
 ---
 

--- a/source/_posts/recommended-reading-thinking.md
+++ b/source/_posts/recommended-reading-thinking.md
@@ -3,7 +3,7 @@ title: 推荐阅读（思维篇）
 categories:
   - Reading
 tags:
-  - Thinking
+  - Independent Thinking
 date: 2024-04-20 00:00:00
 ---
 

--- a/source/_posts/running-android-studio-on-cloud.md
+++ b/source/_posts/running-android-studio-on-cloud.md
@@ -5,7 +5,7 @@ categories:
   - Mobile
   - Android
 tags:
-  - Android Studio
+  - Android
 date: 2020-11-20 20:00:00
 ---
 

--- a/source/_posts/service-provider-interface-optimization.md
+++ b/source/_posts/service-provider-interface-optimization.md
@@ -6,7 +6,7 @@ categories:
   - Booster
 tags:
   - Booster
-  - 性能优化
+  - Performance Optimization
   - SPI
 date: 2020-01-23 00:00:00
 ---

--- a/source/_posts/short-video-preloading-1.md
+++ b/source/_posts/short-video-preloading-1.md
@@ -4,7 +4,7 @@ categories:
   - Computer Science
   - Mobile
 tags:
-  - 预加载
+  - Preloading
 date: 2021-02-10 03:00:00
 ---
 

--- a/source/_posts/short-video-preloading-2.md
+++ b/source/_posts/short-video-preloading-2.md
@@ -4,7 +4,7 @@ categories:
   - Computer Science
   - Mobile
 tags:
-  - 预加载
+  - Preloading
 date: 2021-03-24 07:00:00
 ---
 

--- a/source/_posts/the-fastest-route-is-not-always-straight.md
+++ b/source/_posts/the-fastest-route-is-not-always-straight.md
@@ -3,7 +3,7 @@ title: 谁说世界上没有捷径
 categories:
   - Independent Thinking
 tags:
-  - 独立思考
+  - Independent Thinking
 date: 2020-10-13 00:00:00
 ---
 

--- a/source/_posts/the-first-pot-of-gold.md
+++ b/source/_posts/the-first-pot-of-gold.md
@@ -3,7 +3,7 @@ title: 第一桶金
 categories:
   - Life
 tags:
-  - 赚钱
+  - Finance
 date: 2021-03-04 00:00:00
 ---
 

--- a/source/_posts/the-pain-of-java-8-lambda.md
+++ b/source/_posts/the-pain-of-java-8-lambda.md
@@ -4,7 +4,7 @@ categories:
   - Computer Science
   - Java
 tags:
-  - Java 8
+  - Java
   - Lambda
 date: 2020-04-15 01:00:00
 ---

--- a/source/_posts/the-root-cause-of-chinese-peoples-cultural-unconfidence.md
+++ b/source/_posts/the-root-cause-of-chinese-peoples-cultural-unconfidence.md
@@ -3,7 +3,7 @@ title: 中国人文化不自信的根源
 categories:
   - Independent Thinking
 tags:
-  - 独立思考
+  - Independent Thinking
   - Korea
 date: 2023-09-24 17:00:00
 ---

--- a/source/_posts/truth-and-reality.md
+++ b/source/_posts/truth-and-reality.md
@@ -3,7 +3,7 @@ title: 真相与现实
 categories:
   - Independent Thinking
 tags:
-  - 社会
+  - Society
 date: 2021-06-10 00:00:00
 ---
 

--- a/source/_posts/use-better-metrics-for-build-performance-measurement.md
+++ b/source/_posts/use-better-metrics-for-build-performance-measurement.md
@@ -4,7 +4,7 @@ categories:
   - Computer Science
   - Mobile
 tags:
-  - 独立思考
+  - Independent Thinking
 date: 2024-01-27 23:00:00
 ---
 

--- a/source/_posts/where-the-heart-leads-the-truth-follows.md
+++ b/source/_posts/where-the-heart-leads-the-truth-follows.md
@@ -3,7 +3,7 @@ title: 心之所向，道之所在
 categories:
   - Independent Thinking
 tags:
-  - 独立思考
+  - Independent Thinking
 date: 2024-01-01 16:00:00
 ---
 

--- a/source/_posts/why-i-went-all-in-on-circle.md
+++ b/source/_posts/why-i-went-all-in-on-circle.md
@@ -1,7 +1,7 @@
 ---
 title: 为什么 All in CRCL?
 categories:
-  - Investment
+  - Investing
 tags:
   - Stock
 date: 2025-06-22 16:00:00

--- a/source/_posts/working-as-an-architect-at-didi-0.md
+++ b/source/_posts/working-as-an-architect-at-didi-0.md
@@ -3,7 +3,7 @@ title: 我在滴滴做架构（目录）
 categories:
   - Career
 tags:
-  - 职场
+  - Career
 date: 2020-04-01 00:00:00
 ---
 

--- a/source/_posts/working-as-an-architect-at-didi-1.md
+++ b/source/_posts/working-as-an-architect-at-didi-1.md
@@ -3,7 +3,7 @@ title: 第一章：难逃的墨菲定律
 categories:
   - Career
 tags:
-  - 职场
+  - Career
 date: 2020-01-01 22:22:10
 ---
 

--- a/source/_posts/working-as-an-architect-at-didi-2.md
+++ b/source/_posts/working-as-an-architect-at-didi-2.md
@@ -3,7 +3,7 @@ title: 第二章：涛哥的屠龙之技
 categories:
   - Career
 tags:
-  - 职场
+  - Career
 date: 2020-01-04 00:00:00
 ---
 

--- a/source/_posts/working-as-an-architect-at-didi-3.md
+++ b/source/_posts/working-as-an-architect-at-didi-3.md
@@ -3,7 +3,7 @@ title: 第三章：被吐槽的反人类设计
 categories:
   - Career
 tags:
-  - 职场
+  - Career
 date: 2020-01-13 00:00:00
 ---
 

--- a/source/_posts/working-at-didi.md
+++ b/source/_posts/working-at-didi.md
@@ -2,7 +2,7 @@
 title: 在滴滴工作的那些年
 category: 我在滴滴做架构
 tags:
-  - 职场
+  - Career
 categories:
   - Career
 date: 2019-12-19 00:00:00

--- a/source/_posts/you-wont-be-a-master.md
+++ b/source/_posts/you-wont-be-a-master.md
@@ -3,7 +3,7 @@ title: 你不可能成为大牛
 categories:
   - Career
 tags:
-  - 职场
+  - Career
 date: 2021-05-26 12:00:00
 ---
 


### PR DESCRIPTION
## Summary

- Standardize all 8 Chinese tags to English equivalents (独立思考→Independent Thinking, 职场→Career, 性能优化→Performance Optimization, 教育→Education, 预加载→Preloading, 社会→Society, 赚钱→Finance, 音乐→Music)
- Merge 4 duplicate/similar English tags (Thinking→Independent Thinking, Android Studio→Android, Java 8→Java, Investment→Investing)
- 48 files changed, only YAML frontmatter tags affected, no body content modified

## Test plan

- [x] Verify no Chinese tags remain in frontmatter: `grep -r '  - 独立思考\|  - 职场\|  - 性能优化\|  - 教育\|  - 预加载\|  - 社会\|  - 赚钱\|  - 音乐' source/_posts/`
- [x] Verify no old duplicate tags remain: `grep -r '  - Thinking$\|  - Android Studio$\|  - Java 8$\|  - Investment$' source/_posts/`
- [x] Run `hexo generate` to verify blog builds correctly
- [x] Check tag pages render properly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)