### PR TITLE
Generate per-post OG card images for social sharing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,10 @@ jobs:
         if: steps.cache-nodemodules.outputs.cache-hit != 'true'
         run: |
           npm install
+      - name: Install OG card dependencies
+        run: |
+          pip install Pillow
+          sudo apt-get install -y fonts-wqy-zenhei
       - name: Build
         run: |
           rm -rvf public && mkdir public

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ db.json
 node_modules/
 public/
 .deploy*/
+source/og-cards/

--- a/scripts/generate-og-cards.py
+++ b/scripts/generate-og-cards.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Generate OG card images for blog posts.
+
+Usage: python3 generate-og-cards.py <source_dir> <output_dir>
+
+Reads all markdown files in source_dir/_posts/, generates a 1200x630 card
+image for each post, and saves to output_dir/{slug}.png.
+
+Only regenerates if the post is newer than the existing image.
+"""
+
+import os
+import sys
+import re
+import hashlib
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+# Category color palette
+CATEGORY_COLORS = {
+    'Android':             '#3DDC84',
+    'Architecture Design': '#5C6BC0',
+    'Biology':             '#66BB6A',
+    'Booster':             '#FF7043',
+    'Career':              '#AB47BC',
+    'Cloud':               '#29B6F6',
+    'Computer Science':    '#26A69A',
+    'DIY':                 '#FFA726',
+    'Flutter':             '#42A5F5',
+    'Gradle':              '#02303A',
+    'Graphics':            '#EC407A',
+    'iOS':                 '#007AFF',
+    'Java':                '#E76F00',
+    'Kotlin':              '#7F52FF',
+    'Life':                '#78909C',
+    'Mobile':              '#00ACC1',
+    'Observability':       '#EF5350',
+    'Open Source':         '#43A047',
+    'Reading':             '#8D6E63',
+    'Survival':            '#546E7A',
+    'Investing':           '#FFB300',
+    'Web':                 '#FF5722',
+}
+DEFAULT_COLOR = '#37474F'
+
+WIDTH, HEIGHT = 1200, 630
+FONT_PATH = '/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc'
+SITE_NAME = 'Johnson Lee'
+
+
+def parse_frontmatter(filepath):
+    """Extract title and first category from markdown frontmatter."""
+    text = filepath.read_text(encoding='utf-8')
+    m = re.match(r'^---\s*\n(.*?)\n---', text, re.DOTALL)
+    if not m:
+        return None, None
+
+    fm = m.group(1)
+
+    # title
+    title_m = re.search(r'^title:\s*(.+)$', fm, re.MULTILINE)
+    title = title_m.group(1).strip().strip('"').strip("'") if title_m else None
+
+    # first category
+    cat_m = re.search(r'categories:\s*\n\s*-\s*(.+)', fm)
+    category = cat_m.group(1).strip() if cat_m else None
+
+    return title, category
+
+
+def wrap_text(draw, text, font, max_width):
+    """Wrap text to fit within max_width, return list of lines."""
+    lines = []
+    current = ''
+    for ch in text:
+        test = current + ch
+        bbox = draw.textbbox((0, 0), test, font=font)
+        if bbox[2] - bbox[0] > max_width:
+            if current:
+                lines.append(current)
+            current = ch
+        else:
+            current = test
+    if current:
+        lines.append(current)
+    return lines
+
+
+def generate_card(title, category, output_path):
+    """Generate a single OG card image."""
+    accent = CATEGORY_COLORS.get(category, DEFAULT_COLOR)
+
+    # Parse hex color
+    r = int(accent[1:3], 16)
+    g = int(accent[3:5], 16)
+    b = int(accent[5:7], 16)
+
+    # Dark background
+    img = Image.new('RGB', (WIDTH, HEIGHT), '#1a1a2e')
+    draw = ImageDraw.Draw(img)
+
+    # Accent bar on left
+    draw.rectangle([0, 0, 8, HEIGHT], fill=accent)
+
+    # Category label
+    font_cat = ImageFont.truetype(FONT_PATH, 28)
+    if category:
+        draw.text((60, 50), category.upper(), fill=accent, font=font_cat)
+
+    # Title
+    font_title = ImageFont.truetype(FONT_PATH, 56)
+    lines = wrap_text(draw, title, font_title, WIDTH - 120)
+    lines = lines[:4]  # max 4 lines
+
+    y = 120
+    for line in lines:
+        draw.text((60, y), line, fill='#EEEEEE', font=font_title)
+        y += 72
+
+    # Bottom: site name + terminal prompt icon
+    font_site = ImageFont.truetype(FONT_PATH, 24)
+    draw.text((60, HEIGHT - 70), f'>_ {SITE_NAME}', fill='#666666', font=font_site)
+
+    # Bottom accent line
+    draw.rectangle([60, HEIGHT - 30, 200, HEIGHT - 26], fill=accent)
+
+    img.save(output_path, 'PNG', optimize=True)
+
+
+def main():
+    source_dir = Path(sys.argv[1])
+    output_dir = Path(sys.argv[2])
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    posts_dir = source_dir / '_posts'
+    if not posts_dir.exists():
+        print('No _posts directory found')
+        return
+
+    count = 0
+    skipped = 0
+
+    for md in sorted(posts_dir.glob('*.md')):
+        slug = md.stem
+        out_path = output_dir / f'{slug}.png'
+
+        # Skip if image is newer than source
+        if out_path.exists() and out_path.stat().st_mtime >= md.stat().st_mtime:
+            skipped += 1
+            continue
+
+        title, category = parse_frontmatter(md)
+        if not title:
+            continue
+
+        generate_card(title, category, out_path)
+        count += 1
+
+    print(f'OG cards: {count} generated, {skipped} skipped (up to date)')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/og-card-generator.js
+++ b/scripts/og-card-generator.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+hexo.extend.filter.register('before_generate', () => {
+  const sourceDir = hexo.source_dir;
+  const outputDir = path.join(sourceDir, 'og-cards');
+  const script = path.join(hexo.base_dir, 'scripts', 'generate-og-cards.py');
+
+  hexo.log.info('Generating OG card images...');
+
+  try {
+    const result = execSync(`python3 "${script}" "${sourceDir}" "${outputDir}"`, {
+      encoding: 'utf-8',
+      timeout: 120000,
+    });
+    if (result.trim()) {
+      hexo.log.info(result.trim());
+    }
+  } catch (err) {
+    hexo.log.warn('OG card generation failed:', err.message);
+  }
+});

--- a/themes/maupassant/layout/_partial/head.pug
+++ b/themes/maupassant/layout/_partial/head.pug
@@ -16,7 +16,9 @@ head
     meta(property='og:description', content=seoDescription)
     meta(property='og:type', content=is_post() ? 'article' : 'website')
     meta(property='og:url', content=page.permalink || config.url + url_for(page.path))
-    meta(property='og:image', content=config.url + url_for('logo.png'))
+    -
+      var ogImage = is_post() ? config.url + url_for('og-cards/' + page.slug + '.png') : config.url + url_for('logo.png');
+    meta(property='og:image', content=ogImage)
     meta(property='og:site_name', content=config.title)
     meta(property='og:locale', content='zh_CN')
     if is_post()
@@ -29,7 +31,7 @@ head
     meta(name='twitter:card', content='summary')
     meta(name='twitter:title', content=page.title || config.title)
     meta(name='twitter:description', content=seoDescription)
-    meta(name='twitter:image', content=config.url + url_for('logo.png'))
+    meta(name='twitter:image', content=ogImage)
     block title
     link(rel='stylesheet', type='text/css', href='https://fonts.googleapis.com/css?family=Open+Sans:400,600,300')
     link(rel='stylesheet', type='text/css', href=url_for(theme.css) + '/style.css')

--- a/themes/maupassant/layout/base.pug
+++ b/themes/maupassant/layout/base.pug
@@ -19,7 +19,10 @@ html(lang=config.language)
   include _partial/head.pug
 
   body: .body_container
-    img(src=url_for('logo.png'), style='display:none')
+    if is_post()
+      img(src=url_for('og-cards/' + page.slug + '.png'), style='display:none')
+    else
+      img(src=url_for('logo.png'), style='display:none')
     #header
       .site-name
         h1.hidden= current_title


### PR DESCRIPTION
- Add Python script to generate 1200x630 card images per post (title + category color + site branding)
- Add Hexo plugin to trigger generation during build
- Update og:image/twitter:image to use per-post cards
- Add hidden img tag in body for WeChat crawler
- Update CI workflow to install Pillow and CJK fonts
- Cards are gitignored (generated at build time)