### PR TITLE
feat: add English Atom feed at /en/atom.xml

### DIFF
--- a/scripts/en-feed.js
+++ b/scripts/en-feed.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Custom Atom feed generator for English posts.
-// Emits /en/atom.xml containing only posts with `lang: en`,
+// Emits /atom.en.xml containing only posts with `lang: en`,
 // using the /en/YYYY/MM/DD/slug/ permalinks produced by scripts/i18n.js.
 
 const { encodeURL, full_url_for } = require('hexo-util');
@@ -36,7 +36,7 @@ hexo.extend.generator.register('en_feed', function(locals) {
 
   const siteUrl = config.url.replace(/\/+$/, '');
   const enHomeUrl = siteUrl + '/en/';
-  const feedUrl = siteUrl + '/en/atom.xml';
+  const feedUrl = siteUrl + '/atom.en.xml';
 
   let posts = locals.posts
     .filter(post => post.lang === 'en' && post.draft !== true)
@@ -121,7 +121,7 @@ hexo.extend.generator.register('en_feed', function(locals) {
   lines.push('</feed>');
 
   return {
-    path: 'en/atom.xml',
+    path: 'atom.en.xml',
     data: lines.join('\n')
   };
 });

--- a/scripts/en-feed.js
+++ b/scripts/en-feed.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// Custom Atom feed generator for English posts.
+// Emits /en/atom.xml containing only posts with `lang: en`,
+// using the /en/YYYY/MM/DD/slug/ permalinks produced by scripts/i18n.js.
+
+const { encodeURL, full_url_for } = require('hexo-util');
+
+function xmlEscape(str) {
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function stripControlChars(str) {
+  // eslint-disable-next-line no-control-regex
+  return String(str || '').replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+}
+
+function getEnPostPath(post) {
+  const slug = post.slug.replace(/\.en$/, '');
+  return 'en/' + post.date.format('YYYY/MM/DD') + '/' + slug + '/';
+}
+
+hexo.extend.generator.register('en_feed', function(locals) {
+  const config = this.config;
+  const feedConfig = config.feed || {};
+  const limit = feedConfig.limit || 100;
+  const contentLimit = feedConfig.content_limit || 140;
+  const contentLimitDelim = feedConfig.content_limit_delim || ' ';
+  const includeContent = feedConfig.content;
+
+  const siteUrl = config.url.replace(/\/+$/, '');
+  const enHomeUrl = siteUrl + '/en/';
+  const feedUrl = siteUrl + '/en/atom.xml';
+
+  let posts = locals.posts
+    .filter(post => post.lang === 'en' && post.draft !== true)
+    .sort('-date');
+
+  const postsArray = posts.toArray ? posts.toArray() : Array.prototype.slice.call(posts);
+  if (postsArray.length === 0) return [];
+
+  const limited = limit ? postsArray.slice(0, limit) : postsArray;
+
+  const firstPost = limited[0];
+  const feedUpdated = (firstPost.updated || firstPost.date).toISOString();
+
+  const entries = limited.map(post => {
+    const permalink = siteUrl + '/' + getEnPostPath(post);
+    const published = post.date.toISOString();
+    const updated = (post.updated || post.date).toISOString();
+
+    let summary = post.description || post.excerpt || '';
+    if (!summary && post.content) {
+      let shortContent = post.content.substring(0, contentLimit);
+      if (contentLimitDelim) {
+        const delimPos = shortContent.lastIndexOf(contentLimitDelim);
+        if (delimPos > -1) shortContent = shortContent.substring(0, delimPos);
+      }
+      summary = shortContent;
+    }
+
+    const categories = post.categories && post.categories.toArray
+      ? post.categories.toArray()
+      : [];
+    const tags = post.tags && post.tags.toArray ? post.tags.toArray() : [];
+
+    const parts = [];
+    parts.push('  <entry>');
+    parts.push('    <title>' + xmlEscape(post.title) + '</title>');
+    parts.push('    <link href="' + encodeURL(permalink) + '"/>');
+    parts.push('    <id>' + encodeURL(permalink) + '</id>');
+    parts.push('    <published>' + published + '</published>');
+    parts.push('    <updated>' + updated + '</updated>');
+
+    if (includeContent && post.content) {
+      parts.push('    <content type="html"><![CDATA[' + stripControlChars(post.content) + ']]></content>');
+    }
+    if (summary) {
+      parts.push('    <summary type="html">' + xmlEscape(stripControlChars(summary)) + '</summary>');
+    }
+
+    categories.forEach(cat => {
+      parts.push('    <category term="' + xmlEscape(cat.name) + '" scheme="' + encodeURL(cat.permalink) + '"/>');
+    });
+    tags.forEach(tag => {
+      parts.push('    <category term="' + xmlEscape(tag.name) + '" scheme="' + encodeURL(tag.permalink) + '"/>');
+    });
+
+    parts.push('  </entry>');
+    return parts.join('\n');
+  });
+
+  const iconUrl = feedConfig.icon ? full_url_for.call(this, feedConfig.icon) : '';
+  const feedTitle = config.title + ' (English)';
+  const feedSubtitle = 'English posts on AI-native engineering, Agent architecture, LLM engineering, and Harness Engineering.';
+
+  const lines = [];
+  lines.push('<?xml version="1.0" encoding="utf-8"?>');
+  lines.push('<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">');
+  lines.push('  <title>' + xmlEscape(feedTitle) + '</title>');
+  if (iconUrl) lines.push('  <icon>' + xmlEscape(iconUrl) + '</icon>');
+  lines.push('  <subtitle>' + xmlEscape(feedSubtitle) + '</subtitle>');
+  lines.push('  <link href="' + encodeURL(feedUrl) + '" rel="self"/>');
+  lines.push('  <link href="' + encodeURL(enHomeUrl) + '"/>');
+  lines.push('  <updated>' + feedUpdated + '</updated>');
+  lines.push('  <id>' + encodeURL(enHomeUrl) + '</id>');
+  if (config.author) {
+    lines.push('  <author>');
+    lines.push('    <name>' + xmlEscape(config.author) + '</name>');
+    if (config.email) lines.push('    <email>' + xmlEscape(config.email) + '</email>');
+    lines.push('  </author>');
+  }
+  lines.push('  <generator uri="https://hexo.io/">Hexo</generator>');
+  lines.push(entries.join('\n'));
+  lines.push('</feed>');
+
+  return {
+    path: 'en/atom.xml',
+    data: lines.join('\n')
+  };
+});

--- a/themes/maupassant/layout/_partial/head.pug
+++ b/themes/maupassant/layout/_partial/head.pug
@@ -51,7 +51,7 @@ head
     link(rel='apple-touch-icon-precomposed', href=url_for('apple-touch-icon.png'))
     if config.feed
       link(rel='alternate', type=feed_type, href=url_for(config.feed.path), title=config.title)
-      link(rel='alternate', type=feed_type, href=url_for('en/atom.xml'), title=config.title + ' (English)', hreflang='en')
+      link(rel='alternate', type=feed_type, href=url_for('atom.en.xml'), title=config.title + ' (English)', hreflang='en')
     script(type='text/javascript', src=url_for(theme.js) + '/weather-theme.js', defer)
     script(type='text/javascript', src=url_for(theme.js) + '/weather-canvas.js', defer)
     script(type='text/javascript', src=url_for(theme.js) + '/i18n-switch.js', defer)

--- a/themes/maupassant/layout/_partial/head.pug
+++ b/themes/maupassant/layout/_partial/head.pug
@@ -50,7 +50,8 @@ head
     link(rel='apple-touch-icon', href=url_for('apple-touch-icon.png'))
     link(rel='apple-touch-icon-precomposed', href=url_for('apple-touch-icon.png'))
     if config.feed
-      link(rel='alternate', type=feed_type, href=url_for(config.feed.path))
+      link(rel='alternate', type=feed_type, href=url_for(config.feed.path), title=config.title)
+      link(rel='alternate', type=feed_type, href=url_for('en/atom.xml'), title=config.title + ' (English)', hreflang='en')
     script(type='text/javascript', src=url_for(theme.js) + '/weather-theme.js', defer)
     script(type='text/javascript', src=url_for(theme.js) + '/weather-canvas.js', defer)
     script(type='text/javascript', src=url_for(theme.js) + '/i18n-switch.js', defer)


### PR DESCRIPTION
Generate a dedicated Atom feed containing only English posts (lang: en),
using the /en/YYYY/MM/DD/slug/ permalinks from scripts/i18n.js, and
advertise it via an hreflang="en" alternate link in every page head so
feed readers and browsers can discover it.