### PR TITLE
fix: emit full-text <content> in Atom feeds

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -132,7 +132,7 @@ feed:
   path: atom.xml
   limit: 100
   hub:
-  content:
+  content: true
   content_limit: 140
   content_limit_delim: ' '
   order_by: -date

--- a/scripts/en-feed.js
+++ b/scripts/en-feed.js
@@ -32,7 +32,10 @@ hexo.extend.generator.register('en_feed', function(locals) {
   const limit = feedConfig.limit || 100;
   const contentLimit = feedConfig.content_limit || 140;
   const contentLimitDelim = feedConfig.content_limit_delim || ' ';
-  const includeContent = feedConfig.content;
+  // Default to full-text when `feed.content` is unset or truthy. Explicit
+  // `feed.content: false` in _config.yml disables it (for both atom.xml
+  // and atom.en.xml).
+  const includeContent = feedConfig.content !== false;
 
   const siteUrl = config.url.replace(/\/+$/, '');
   const enHomeUrl = siteUrl + '/en/';


### PR DESCRIPTION
feed.content in _config.yml was left empty, which YAML parses as null. hexo-generator-feed's Object.assign pattern then overrode its own default (content: true) with null, so the main atom.xml shipped only <summary> (~140 chars, effectively the opening paragraph). dev.to and similar RSS importers fell back to the preview because no <content> tag was present.

Set content: true explicitly so both the main atom.xml and the custom atom.en.xml include <content type="html"> with the full rendered post. en-feed.js reads the same feed.content key so one switch controls both feeds.