### PR TITLE
Add Graphite code context post

### DIFF
--- a/source/_posts/graphite-agent-bytecode-context.en.md
+++ b/source/_posts/graphite-agent-bytecode-context.en.md
@@ -1,0 +1,103 @@
+---
+title: "Graphite: Code Is Context"
+date: 2026-05-11 20:00:00
+categories:
+  - Harness Engineering
+tags:
+  - Graphite
+  - AI
+  - Agent
+  - MCP
+  - Bytecode
+  - Static Analysis
+lang: en
+i18n_key: graphite-agent-bytecode-context
+---
+
+Many people assume that making an Agent understand code means giving it more source code: a bigger context window, better embeddings, smarter RAG, and a finer AST index. I almost believed that too.
+
+Until I asked an Agent to clean up AB experiment code: it quickly found a bunch of call sites, then said, "Done." The real question was not whether the Agent could read code, but how I could prove it had not missed the 201st call site. For an Agent, context should not just be source text; **code itself should become context that an Agent can query, verify, and reason about.** Graphite is built for exactly this problem.
+
+<!-- more -->
+
+## Source Code Is Not the Truth of a Program
+
+Most "code understanding" tools today still stop at the source level. Tree-sitter parses source code into an AST. Language Servers provide symbols, references, and definitions. Embeddings turn code blocks into vectors. RAG then stuffs the relevant snippets back into the context window. All of this is useful, but it answers "what does the code look like?", not "how does the program run?"
+
+Those are very different questions. Take a simple example: AB experiment IDs are rarely written directly at the call site. An ID might first be defined as a constant, then assigned to a local variable. It might be imported from another module. It might be wrapped in a helper method and only later passed into the real AB SDK. In the source code, you might see:
+
+```kotlin
+abClient.getOption(EXPERIMENT_ID)
+```
+
+The AST can tell you that there is an identifier named `EXPERIMENT_ID`. But what is its value? It may live in another file, another module, or only reach the argument after several variable assignments. A human can trace that slowly, and an Agent can guess through it slowly, but guessed structure cannot be ground truth.
+
+**Source code is written for humans. Bytecode is what the machine actually executes.**
+
+If an Agent needs to understand a JVM system, it cannot stop at the syntax tree. It has to cross the compiler boundary and see the world after compilation.
+
+## AST Is the Map, Bytecode Is the Terrain
+
+Tree-sitter is good, but it is not static analysis. It can tell you that there is a function here, a call there, and an argument under some node. For editors, syntax highlighting, and local refactoring, that is enough; for Agentic Engineering, it is not. The Agent is not dealing with one file or one class. It is dealing with a long-lived business system.
+
+In a ten-year-old JVM monorepo, the real logic often does not live on the surface of the source code. Experiment IDs may flow through constants. Constants may be defined in another module. Call sites may hide behind helper methods. The same AB SDK may be wrapped by several layers of business APIs. Spring endpoints may come from annotations on a parent class, Jackson field names may be hidden inside annotations, and enum values may have to be recovered from bytecode initialization logic. These are not problems you solve by adding a few more AST queries.
+
+Of course you can ask the Agent to read more source code, but the context window is not magic. The more you read, the more tokens you spend, the more noise you introduce, and the more the conclusion sounds like "I think." **Agents do not lack reading ability. They lack verifiable structure.**
+
+Graphite does something simple: it builds a program graph from compiled bytecode. Nodes are methods, fields, constants, call sites, arguments, and return values. Edges are call relationships, data flow, type relationships, control flow, and annotation relationships. In other words, Graphite turns "how the program is actually connected" into a graph that can be queried. That graph is not hallucinated by an LLM. It comes from compiler output.
+
+## Agents Should Not Discover Structure by Themselves
+
+When we ask Agents to work on code today, we are often betting on one sentence: "Read all these files and tell me what needs to change." That sounds natural, but it hides an assumption: the Agent has to discover the structure by itself. It has to decide who calls whom, where an argument comes from, whether an annotation is inherited, what the type hierarchy is, and whether a constant flows into the target API.
+
+This is absurd. These questions should not be delegated to an LLM in the first place. LLMs are good at semantic reasoning; they are not the right tool for deterministic graph traversal. Asking an LLM to find call sites across millions of tokens is like asking a very smart person to scan a phone book by eye. It can be done. It just should not be.
+
+Graphite creates a cleaner division of labor: the Agent asks the question, Graphite returns facts, and the Agent reasons over those facts. For example, if the Agent wants to know every experiment ID passed into `AbClient.getOption()`, it does not need to read 500 files. It can query the graph:
+
+```cypher
+MATCH (c:IntConstant)-[:DATAFLOW*]->(cs:CallSiteNode)
+WHERE cs.callee_class = 'com.example.ab.AbClient'
+  AND cs.callee_name = 'getOption'
+RETURN c.value, cs.caller_class, cs.caller_name
+```
+
+The result is not "these might be relevant." The result is that these data-flow paths exist in the graph. That is the kind of context Agentic Engineering needs. **The LLM should not be responsible for discovering structure. It should be responsible for understanding the intent behind structure.**
+
+## 6, or 19
+
+Graphite started as a way to verify AB experiment cleanup. At first, I scanned the code the traditional way: patterns, AST, grep, call-site search. It found some of the places, but it never felt complete. Later, after building a graph from bytecode and tracing from constant nodes along data-flow edges into the target call sites, the result became 19. Not 6.
+
+The extra cases were exactly the ones AST-level approaches tend to miss: local variable propagation, cross-module constants, and indirect calls inside conditional branches. That difference is critical. If you are only doing code search, missing a few spots may not matter. But if you ask an Agent to delete code, change interfaces, migrate frameworks, or clean up dead code automatically, one missed call site can become a production incident.
+
+The more capable Agents become, the more determinism we need. That sounds counterintuitive: many people assume that as models get stronger, tools become less important. The opposite is true. The stronger the model, the more it needs reliable tools to ground its ability in facts. Without structured context like Graphite, the Agent's ceiling is "a smart intern who has read a lot of code." With it, the Agent becomes closer to an engineer who can query the truth of the system at any moment.
+
+## After MCP, Graphite Becomes the Agent's Eyes
+
+Graphite started as a CLI. You can build and query a graph like this:
+
+```bash
+brew tap johnsonlee/tap
+brew install graphite graphite-explore
+
+graphite build app.jar -o /data/app-graph --include com.example
+graphite query /data/app-graph "MATCH (n:CallSiteNode) RETURN n LIMIT 10"
+graphite-explore /data/app-graph --port 8080
+```
+
+That already solves many static analysis problems, but MCP is where it gets interesting. Expose Graphite through MCP to Claude Code or another Agent, and the Agent no longer needs to load the whole repository into its context window. It can ask the graph directly: which call sites reach this method? Which Controller owns this endpoint? Is this annotation inherited? Where does this constant eventually flow? Which subtypes does this type have? Why is this dead branch unreachable?
+
+In the past, Agents answered these questions by reading source code, guessing structure, and stitching together context. Now they can query the graph. This is not just about saving tokens; it changes the way the work happens. The old code context was text. The next code context is a queryable program graph.
+
+## This Is Not About Replacing Source Code
+
+I do not want to overstate the claim. Graphite will not tell you why the business was designed this way. It will not automatically decide whether an experiment can be deleted. Bytecode can be precise, but it can only answer what structurally happens in the program. That is exactly its value: it does not take work away from the LLM, it removes the work the LLM should not be doing.
+
+Source code still matters. PRs still need review. Business semantics still require humans and Agents to reason together. But before that, we should at least know the real structure of the system. Without that step, every attempt to make Agents "understand code" becomes a long, detailed description built from partial contact with the system. The description may get richer, but you still do not know whether it is complete.
+
+## Start Where the Compiler Ends
+
+The old software toolchain was designed around humans. IDEs help humans jump around, grep helps humans search, ASTs help humans refactor, and documentation helps humans understand. Once Agents enter the workflow, the toolchain has to change, because Agents should not read code the same way humans do. Humans read source because they cannot directly read program structure. Agents do not have that limitation. They can call tools, query graphs, and combine deterministic analysis with probabilistic reasoning.
+
+That is what Graphite is trying to do. It is not another smarter grep. It is a map for Agents that is closer to real execution semantics. Source code is input. Bytecode is fact. A program graph is context the Agent can use. Do not stuff code into a context window. Turn code itself into context the Agent can query, verify, and reason about. That is what "Code Is Context" means.
+
+If every Agent on an engineering team could query call graphs, data flow, type hierarchies, and annotation relationships in real time, then "understanding code" would be redefined. It would no longer mean how many files you have read. It would mean whether you can ask the right questions and get reliable answers. The tools are changing. The work is changing. Code context should change too. Are you still planning to stuff millions of tokens of source code into a context window?

--- a/source/_posts/graphite-agent-bytecode-context.md
+++ b/source/_posts/graphite-agent-bytecode-context.md
@@ -1,0 +1,102 @@
+---
+title: "Graphite: Code 即上下文"
+date: 2026-05-11 20:00:00
+categories:
+  - Harness Engineering
+tags:
+  - Graphite
+  - AI
+  - Agent
+  - MCP
+  - Bytecode
+  - Static Analysis
+i18n_key: graphite-agent-bytecode-context
+---
+
+很多人以为，让 Agent 理解代码，就是给它更多源码：更大的 context window，更好的 embedding，更聪明的 RAG，更细的 AST index。我以前也差点信了。
+
+直到我让 Agent 清理 AB 实验代码：它很快扫出一堆调用点，然后说“清完了”。真正的问题不是 Agent 能不能读代码，而是我怎么证明它没有漏掉第 201 个调用点。对 Agent 来说，context 不应该只是源码文本；**Code 本身就应该成为 Agent 可以查询、验证、推理的上下文。** Graphite 就是为这个问题做的。
+
+<!-- more -->
+
+## 源码不是程序的真相
+
+今天大部分“代码理解”工具，都还停在源码层。Tree-sitter 把源码解析成 AST，Language Server 提供 symbol、reference、definition，Embedding 把代码块变成向量，RAG 再把相关片段塞回 context window。这些东西当然有用，但它们解决的是“代码长什么样”，不是“程序会怎么跑”。
+
+这两个问题差很远。举个最简单的例子：AB 实验 ID 很少老老实实写在调用点上。它可能先定义成常量，再赋给局部变量；可能从另一个 module import 过来；也可能被包装进一个 helper method，最后才传给真正的 AB SDK。源码里你看到的是：
+
+```kotlin
+abClient.getOption(EXPERIMENT_ID)
+```
+
+AST 只能告诉你这里有个标识符叫 `EXPERIMENT_ID`。至于它的值是多少，可能在另一个文件，另一个 module，甚至经过几次变量传递之后才落到参数里。人脑可以慢慢追，Agent 也可以慢慢猜，但猜出来的东西不能当 ground truth。
+
+**源码是给人读的，bytecode 才是机器真正执行的代码。**
+
+Agent 要理解一个 JVM 系统，不能停在语法树那一层。它得越过源码，看见编译器之后的世界。
+
+## AST 是地图，bytecode 是地形
+
+Tree-sitter 很好，但它不是静态分析。它能告诉你这里有一个函数，那里有一个调用，某个节点下面挂着某个参数。对编辑器、语法高亮、局部重构来说，这已经够了；但对 Agentic Engineering 来说，不够。因为 Agent 面对的不是一个文件，也不是一个类，而是一个长期演化的业务系统。
+
+十年历史的 JVM 单体仓库里，真实逻辑往往不在源码表面：实验 ID 可能通过常量传递，常量可能定义在另一个 module，调用点可能藏在 helper method 后面，同一个 AB SDK 可能被封装成几层业务 API。Spring endpoint 可能来自父类注解，Jackson 字段名可能藏在 annotation 里，枚举值可能要从 bytecode 的初始化逻辑里反推。这些东西，不是 AST 上多写几个 query 就能解决的。
+
+你当然可以让 Agent 读更多源码，但 context window 不是魔法。读得越多，token 越贵，噪声越大，结论越像“我觉得”。**Agent 不缺阅读能力，缺的是可验证的结构。**
+
+Graphite 做的事情很简单：从编译后的 bytecode 构建程序图。节点是方法、字段、常量、调用点、参数、返回值；边是调用关系、数据流、类型关系、控制流、注解关系。换句话说，它把“程序真正怎么连在一起”变成一张可以查询的图。这张图不是 LLM 幻觉出来的，它来自编译器产物。
+
+## Agent 不该自己发现结构
+
+过去我们让 Agent 干活，大部分时候是在赌一句话：“你把这些文件都读一遍，然后告诉我哪里要改。”这句话听起来很自然，但里面有个隐藏假设：Agent 必须自己发现结构。它要自己判断谁调用了谁，参数从哪里来，注解有没有继承，类型层次是什么，某个常量有没有流进目标 API。
+
+这其实很荒谬。这些问题本来就不该交给 LLM。LLM 擅长的是语义推理，不是做确定性的图遍历。让它在几百万 token 里找调用点，就像让一个很聪明的人用肉眼翻电话簿：不是不能做，是没必要。
+
+Graphite 的分工更干净：Agent 负责提出问题，Graphite 负责返回事实，Agent 再基于事实做判断。比如 Agent 想知道所有传给 `AbClient.getOption()` 的实验 ID，不需要读 500 个文件，只要查图：
+
+```cypher
+MATCH (c:IntConstant)-[:DATAFLOW*]->(cs:CallSiteNode)
+WHERE cs.callee_class = 'com.example.ab.AbClient'
+  AND cs.callee_name = 'getOption'
+RETURN c.value, cs.caller_class, cs.caller_name
+```
+
+结果不是“可能有这些”，而是图上确实存在这些数据流。这才是 Agentic Engineering 需要的上下文。**LLM 不应该负责发现结构，它应该负责理解结构背后的意图。**
+
+## 6 个，还是 19 个
+
+最早做 Graphite，是为了验证 AB 实验清理。那时我先用传统方式扫：pattern、AST、grep、调用点搜索。结果能找到一部分，但总觉得不踏实。后来把 bytecode 建图，再从常量节点沿着数据流追到目标调用点，结果变成了 19 个，不是 6 个。
+
+多出来的那些，正是 AST 很容易漏掉的地方：局部变量传递、跨 module 常量、条件分支里的间接调用。这类差异很致命。如果你只是做 code search，漏几个点无所谓；但如果你让 Agent 自动删代码、改接口、迁移框架、清理 dead code，漏掉一个点就可能是生产事故。
+
+Agent 越能干，我们越需要确定性。这听起来有点反直觉，很多人以为模型越强，工具越不重要，实际正好相反。模型越强，越需要可靠工具把它的能力约束在事实之上。没有 Graphite 这类结构化上下文，Agent 的上限是“读了很多代码的聪明实习生”；有了它，Agent 才更像一个能随时查询系统真相的工程师。
+
+## MCP 之后，Graphite 变成 Agent 的眼睛
+
+Graphite 最初是 CLI。你可以这样建图：
+
+```bash
+brew tap johnsonlee/tap
+brew install graphite graphite-explore
+
+graphite build app.jar -o /data/app-graph --include com.example
+graphite query /data/app-graph "MATCH (n:CallSiteNode) RETURN n LIMIT 10"
+graphite-explore /data/app-graph --port 8080
+```
+
+这已经能解决很多静态分析问题，但真正有意思的是 MCP。把 Graphite 通过 MCP 暴露给 Claude Code 或其他 Agent，Agent 就不需要把整个仓库读进 context window，而是可以直接问图：这个方法有哪些调用点？这个 endpoint 来自哪个 Controller？这个 annotation 有没有继承？这个常量最后流向了哪里？这个类型有哪些 subtype？这段 dead branch 为什么不可达？
+
+过去 Agent 回答这些问题，要靠读源码、猜结构、拼上下文；现在它可以查图。这不是简单省 token，而是工作方式变了。以前的代码上下文是文本，以后的代码上下文是可查询的程序图。
+
+## 这不是为了替代源码
+
+我不想把话说得太满。Graphite 不会告诉你业务为什么这么设计，也不会自动判断一个实验能不能删。bytecode 再准确，也只能回答“程序结构上发生了什么”。但这恰恰是它的价值：它不抢 LLM 的活，它把 LLM 不该干的脏活拿走。
+
+源码仍然重要，PR 仍然要 review，业务语义仍然要人和 Agent 一起判断。但在此之前，至少我们应该先知道系统真实的结构是什么。没有这一步，所有“让 Agent 理解代码”的方案，都有点像让人闭着眼摸大象：摸得越久，描述越详细，但你还是不知道它有没有摸全。
+
+## 从编译器结束的地方开始
+
+过去的软件工具链，是围绕人设计的。IDE 帮人跳转，grep 帮人搜索，AST 帮人重构，文档帮人理解。Agent 加进来之后，工具链需要变，因为 Agent 不应该像人一样读代码。人读源码，是因为人没法直接读程序结构；Agent 没这个限制。它可以调用工具，可以查询图，可以把确定性分析和概率推理组合起来。
+
+这也是 Graphite 想做的事。不是再造一个更聪明的 grep，而是给 Agent 一张更接近真实执行语义的地图。源码是输入，bytecode 是事实，program graph 是 Agent 能用的上下文。不是把 code 塞进 context window，而是把 code 本身变成 Agent 可以查询、验证、推理的上下文。这就是“Code 即上下文”。
+
+如果未来的工程团队里，每个 Agent 都能实时查询调用图、数据流、类型层次和注解关系，那么“理解代码”这件事本身就会被重新定义。不是读完多少文件，而是能不能问对问题，并拿到可靠答案。工具在变，工作在变，代码上下文也该变了。你还准备继续把几百万 token 的源码塞进 context window 吗？


### PR DESCRIPTION
## Summary
- add the Chinese post "Graphite: Code 即上下文"
- add the matching English i18n post "Graphite: Code Is Context"
- keep both posts on the same i18n_key and place the excerpt after the two opening paragraphs

## Verification
- npm run build (passes; existing OG card PIL warning remains)