### PR TITLE
fix i18n pagination

### DIFF
--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -1,5 +1,10 @@
 'use strict';
 
+var indexGenerator = require('hexo-generator-index/lib/generator');
+var archiveGenerator = require('hexo-generator-archive/lib/generator');
+var categoryGenerator = require('hexo-generator-category/lib/generator');
+var tagGenerator = require('hexo-generator-tag/lib/generator');
+
 var i18nMap = {};
 
 // Keep .en in slug — default generator creates /yyyy/mm/dd/xxx.en/ (harmless)
@@ -33,6 +38,59 @@ function getPostUrl(post) {
   }
   return '/' + datePath + '/' + slug + '/';
 }
+
+function isDefaultLangPost(post) {
+  return post.lang !== 'en';
+}
+
+function withDefaultLangPosts(locals) {
+  return Object.assign({}, locals, {
+    posts: locals.posts.filter(isDefaultLangPost)
+  });
+}
+
+function cloneTermWithDefaultLangPosts(term) {
+  var posts = term.posts.filter(isDefaultLangPost);
+  var clone = Object.create(term);
+  Object.defineProperty(clone, 'posts', {
+    value: posts,
+    enumerable: true
+  });
+  Object.defineProperty(clone, 'length', {
+    value: posts.length,
+    enumerable: true
+  });
+  return clone;
+}
+
+function withDefaultLangTerms(locals, key) {
+  var nextLocals = Object.assign({}, locals);
+  nextLocals[key] = locals[key].map(cloneTermWithDefaultLangPosts);
+  nextLocals[key].toArray = function() {
+    return nextLocals[key];
+  };
+  return nextLocals;
+}
+
+// Override the default list generators so Chinese pagination is calculated
+// after filtering out English translation posts.
+hexo.extend.generator.register('index', function(locals) {
+  return indexGenerator.call(this, withDefaultLangPosts(locals));
+});
+
+if (!(hexo.config.archive && hexo.config.archive.enabled === false)) {
+  hexo.extend.generator.register('archive', function(locals) {
+    return archiveGenerator.call(this, withDefaultLangPosts(locals));
+  });
+}
+
+hexo.extend.generator.register('category', function(locals) {
+  return categoryGenerator.call(this, withDefaultLangTerms(locals, 'categories'));
+});
+
+hexo.extend.generator.register('tag', function(locals) {
+  return tagGenerator.call(this, withDefaultLangTerms(withDefaultLangPosts(locals), 'tags'));
+});
 
 // Inject i18n data into template locals
 hexo.extend.filter.register('template_locals', function(locals) {

--- a/themes/maupassant/layout/index.pug
+++ b/themes/maupassant/layout/index.pug
@@ -7,7 +7,9 @@ block title
     title= config.title
 
 block content
-  - var posts = page.posts.toArray().filter(function(p) { return p.lang !== 'en'; })
+  - var posts = page.posts.toArray()
+  if page._i18n_filter_en
+    - posts = posts.filter(function(p) { return p.lang !== 'en'; })
   for post in posts
     .post
       h1.post-title


### PR DESCRIPTION
## Summary

Fixes the i18n pagination regression where Chinese list pages displayed about half the configured number of posts after English translations were added.

## Root Cause

The default Hexo list generators paginated all posts first, then the theme filtered `lang: en` posts at render time. With bilingual post pairs, each 10-item page often rendered only around 5 Chinese posts.

## Changes

- Override the default index/archive/category/tag generators in `scripts/i18n.js` to filter English posts before pagination.
- Keep the index template language-aware so `/en/` index pages continue rendering English posts instead of being filtered out.

## Validation

- Ran `npm run clean`
- Ran `npm run build`
- Verified generated post counts:
  - `public/index.html`: 10 posts
  - `public/page/2/index.html`: 10 posts
  - `public/en/index.html`: 10 posts
  - `public/en/page/2/index.html`: 10 posts
  - `public/archives/index.html`: 10 posts
  - `public/categories/computer-science/index.html`: 10 posts
  - `public/tags/AI/index.html`: 10 posts

Note: build still reports the existing local `PIL` warning for OG card generation, but Hexo generation succeeds.