### PR TITLE
[codex] add AI PC opportunity post

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -68,7 +68,10 @@ tags:
 - Optimize posts lightly for WeChat readers without turning the article into WeChat-style motivational writing.
 - Mobile reading is the default assumption for WeChat: paragraphs should usually render as 1-3 lines on a phone.
 - Keep sharp judgment sentences as standalone paragraphs when they carry the argument.
-- Merge consecutive explanatory one-liners when they create unnecessary scrolling friction.
+- Do not split explanatory progression into a stack of one-sentence paragraphs. If several adjacent sentences explain the same point, merge them into one paragraph.
+- Standalone one-sentence paragraphs are allowed only for punchlines, sharp contrasts, explicit questions, or section-closing judgments.
+- Three or more consecutive one-sentence paragraphs are a warning sign. Merge them, convert a real enumeration into a list, or deliberately justify the ladder-like rhythm.
+- `npm run check:post-style` enforces this on changed posts; fix failures by improving paragraph rhythm, not by gaming punctuation.
 - Put the section's conclusion or core tension near the beginning of each section so readers can scan.
 - Use bold sparingly for a few key judgments, not as decoration.
 - Keep established English technical terms, but avoid packing too many English-heavy terms into one phone screen when a simpler phrasing works.
@@ -103,6 +106,7 @@ Write in Johnson's style: conversational with peers, opinionated, and concise.
 - Use questions to move the argument forward.
 - Use concrete imagined scenes to make abstract concepts visible.
 - Keep paragraphs breathable. A normal paragraph is usually 2-4 sentences, and mobile-facing posts may be shorter.
+- Before finalizing a post, scan each section for slide-like rhythm: repeated short standalone lines, repeated sentence openings, or list-shaped prose that is not an actual list. Revise those passages into coherent paragraphs.
 
 ### Structure
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "start": "npx hexo server -p 8000 --debug --draft --open",
-    "build": "npm run check:conventions && npx hexo generate && npm run check:quotes",
+    "build": "npm run check:conventions && npm run check:post-style && npx hexo generate && npm run check:quotes",
     "check:conventions": "node tools/check-conventions.js",
+    "check:post-style": "node tools/check-post-style.js",
     "check:quotes": "node tools/check-quotes.js",
     "clean": "npx hexo clean",
     "deploy": "npx hexo deploy"

--- a/source/_posts/ai-pc-real-opportunity.en.md
+++ b/source/_posts/ai-pc-real-opportunity.en.md
@@ -1,0 +1,128 @@
+---
+title: "When AI PCs Become the Next Boom, Where Is the Real Opportunity?"
+date: 2026-05-31 15:39:37
+lang: en
+i18n_key: ai-pc-real-opportunity
+categories:
+  - Independent Thinking
+tags:
+  - AI PC
+  - Token
+  - Local LLM
+  - Agentic Coding
+  - Infrastructure
+  - Enterprise
+---
+
+Over the past few months, many engineers have been absorbed by the excitement around Agentic Coding. It really works: reading repos, changing code, running tests, explaining errors, performing migrations, cleaning up technical debt. Work that used to be too annoying to touch is suddenly movable.
+
+AI now feels like something you cannot avoid using, but once you use it, the bill hurts.
+
+The real danger is not that it is expensive. The real danger is that the more useful it becomes, the more people use it; the more people use it, the less the bill looks like a tool expense and the more it looks like a tax. That is the unfinished part of the previous post, The Wintel Era Is Over.
+
+<!-- more -->
+
+If the PC really is entering a new era, the next correct investment direction is not another AI app, not another laptop with an AI PC sticker, and not another fight over who has higher TOPS. There is only one question worth watching: **who can make high-frequency intelligent work cheaper, stabler, and more controllable after Agentic Coding becomes a necessity?**
+
+## This Quarter Will Force The Question
+
+Agentic Coding is still in the excitement phase. People are seeing that it can do real work. By the end of this quarter, many teams will face a different question: did it actually make delivery faster, or did it simply move labor cost into token cost?
+
+This does not mean Agentic Coding lacks value. It means the opposite. Only genuinely valuable tools expose cost problems this quickly. Nobody uses useless tools every day. Useful tools enter daily workflow; once they do, they are no longer demos, POCs, or innovation budget. They become infrastructure.
+
+The scariest thing about infrastructure is not that it is expensive. It is that every use is uncontrolled. Today, many Agents have an ugly cost structure: the expensive part is not generating a few lines of code. Before that, the Agent reads a dozen files, scans half a repo, asks the model repeatedly, retries after failures, and feeds test logs back into context.
+
+Human engineers also explore and take wrong turns. The difference is that human exploration cost is packaged into salary, while Agent exploration cost shows up line by line in the token bill. So the question is not "should we use AI?" Teams cannot avoid it. The question is: can it become cheap enough to use all the time?
+
+## Do Not Read AI PCs Through TOPS
+
+Most AI PC messaging is still stuck in hardware language: how many TOPS, how much NPU, which benchmark. These numbers are not useless, but they are not the language enterprises actually care about. Enterprises care about more specific questions:
+
+- Can a PR review burn half as many tokens?
+- Can a code migration understand the repo locally before it calls the cloud?
+- Can a failed test log avoid going to the cloud in full every time?
+- Can an Agent task use a local small model to judge difficulty before calling a frontier model?
+
+If AI PCs work, they are not selling "smarter computers." They are selling cheaper intelligent workflows. This is why Wintel was the answer in the previous PC era, but may not be the answer in this one.
+
+The old PC question was: can this machine run Windows software smoothly? The next PC question is: can this machine run enough local intelligence at lower cost? Those are entirely different questions. The first one is about CPU, operating system, and application ecosystem. The second one is about local runtime, model routing, context caching, memory bandwidth, GPU/NPU scheduling, enterprise policy, and developer experience.
+
+Anyone still talking only about TOPS has not entered the real problem.
+
+## First: The Local Intelligence Routing Layer
+
+The next important investment direction is the local model router. Not every app deciding which model to use for each request. Apps are bad at this, because an app usually does not know what hardware exists on each machine, what the battery state is, which local models are available, what enterprise policy allows to leave the device, or whether a task is worth going to the cloud.
+
+This should become a capability shared by the OS, IDE, enterprise platform, and model runtime. A reasonable chain looks like this: simple tasks go to local small models, private context goes to local RAG or enterprise private models, routine tasks go to cheaper models, critical reasoning goes to cloud frontier models, and sensitive tasks are forbidden from leaving the device or enterprise boundary.
+
+That is why Microsoft's [Foundry Local](https://github.com/microsoft/Foundry-Local) matters. It is not just "run a model on your machine for fun." It puts a local model catalog, SDK, automatic hardware acceleration, and an OpenAI-compatible API into the application development path.
+
+[Azure AI Foundry model router](https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-router) points in the same direction: the platform routes according to modes such as quality, cost, and balanced. Today this mostly happens among cloud models, but the logic will eventually move across device, private, and cloud.
+
+The real opportunity is not "we have a model list too." It is who can turn local, private, and cloud models into a governable cost-routing system.
+
+## Second: Make Repo Context Thin
+
+The expensive part of Agentic Coding is not writing code. It is understanding code. Writing one line is cheap; finding the right place to change is expensive. Generating a diff is cheap; knowing whether the diff will break something is expensive.
+
+So the investment opportunity in Agentic Coding is not another chat wrapper. It is the context layer: local code index, repo map, symbol graph, AST and call graph, mapping test failures to source files, log compression, tool result cache, conversation summary, and context deduplication, ranking, and pruning.
+
+These sound unsexy, but they are the cost foundation of Agentic Coding. The repo naturally lives on the PC. IDE state lives on the PC. Terminal output lives on the PC. Local build results live on the PC. Uncommitted diffs live on the PC. If all of that is shoved into a cloud model every time so the model can understand it from scratch, the enterprise is paying tax repeatedly.
+
+A good local context layer should turn 50k tokens of messy context into 15k tokens of useful context before the large model is called. That is not prompt optimization. It is a change in cost structure. Whoever helps Agents start from less zero directly reduces token consumption.
+
+## Third: Turn Repeated Inference Into An Asset
+
+A large share of AI cost is repeated inference. The same repo summary, the same system prompt, the same kind of test failure, the same migration pattern, the same API document, the same enterprise policy. If each one is uploaded, understood, and paid for again, the enterprise is paying tax on repeated work.
+
+So cache becomes important. Not as a small browser-cache style optimization, but as a foundation asset for Agent workflows. Prompt cache, semantic cache, embedding cache, tool result cache, KV cache, and failure pattern cache all move into the infrastructure layer.
+
+AWS Bedrock's [prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) states the point directly: caching long and repeated contexts can reduce latency and input token cost. But that is only the beginning. The valuable cache will happen at the local and workflow layers, because the most stable, reusable, privacy-sensitive context usually lives on the user's device and inside the enterprise environment.
+
+If an engineer asks an Agent to inspect the same repo every day, why should it start from zero every time? If a team fixes the same kind of test failure every day, why should it explain the pattern again? If a company uses the same coding standards every day, why should they be pushed into the prompt repeatedly? For Agentic Coding to move from "useful but painful" to "useful and controllable," cache is unavoidable.
+
+## Fourth: High-Frequency Low-Value Tasks Must Leave The Cloud
+
+This is easy to misunderstand. I am not saying all AI should run locally. In the short to medium term, local models do not need to beat Claude, GPT, or Gemini. They only need to absorb enough high-frequency, low- to mid-complexity tasks.
+
+That includes intent detection, task classification, log summarization, simple code edits, local embeddings, document retrieval, sensitive-content preprocessing, and initial screening before Agent routing. These tasks do not always require the strongest model, but they happen constantly. If all of them go to the cloud, the bill gets ugly.
+
+That is the real enterprise value of AI PCs. They are not replacing frontier models. They are reducing calls that should never have gone to the cloud. In the past, buying a PC meant buying a terminal for accessing cloud services. Next, buying an AI PC should mean buying a local intelligence node that continuously reduces cloud token spend.
+
+If this becomes true, hardware procurement logic changes. 32 GB is no longer just "Chrome feels smoother." 64 GB is no longer just "developers feel better." Memory bandwidth, unified memory, local SSD cache, and GPU/NPU scheduling stop being only specs. They become part of token efficiency.
+
+The question is not whether x86 or Arm has the better religion. It is who can complete the same Agent workflow with lower power, lower latency, and fewer cloud calls.
+
+## Fifth: Agents Need A Cost Brake
+
+The biggest problem with Agents is not only that they make mistakes. It is that they can make mistakes very diligently. A normal LLM call is one input and one output, so cost is at least somewhat estimable. Agents plan, read files, call tools, fail, retry, reflect, and call tools again. Without boundaries, they can turn a simple task into an expensive trip.
+
+A real Agent platform cannot only answer "can the task be completed?" It also has to answer how much we are willing to spend, how many steps it can take, what happens when it exceeds the token budget, whether it should downgrade the model, whether it should switch to a local model, whether it should stop and ask a human, and whether it should reuse an existing cache.
+
+This is not a traditional FinOps dashboard. A dashboard only tells you the money has already burned. The real opportunity is putting cost control into the execution path. An Agent should know its budget before it acts, evaluate marginal return while it acts, and have a brake before it keeps burning money. Otherwise automation just becomes automatic taxation.
+
+## What I Would Watch
+
+If the new era of PC is real, I would not only watch who sells more AI PCs. That is the result, not the cause. I would watch four categories.
+
+First, local AI runtime and model routing layers. They unify CPU, GPU, NPU, local models, private models, and cloud models into one inference entry point that developers do not have to manage by hand.
+
+Second, the context layer for Agentic Coding. They turn repo, IDE, terminal, test, log, and diff data into reusable local intelligence assets instead of repeatedly feeding them to cloud models.
+
+Third, cache and cost-aware execution for Agent workflows. They do not merely display the bill. They reduce waste before each tool call, context assembly, model route, and retry.
+
+Fourth, AI PC ecosystems that can translate hardware specs into economic outcomes. Not "how many TOPS does this machine have?" but "how many cloud tokens can this machine save the team?"
+
+I would be cautious about the opposite: AI PCs without local runtime, TOPS without tokens per watt, Agent automation without cost boundaries, model capability without model routing, and FinOps dashboards that do not enter the execution chain. These may get attention, but they struggle to answer the real question.
+
+## The Point
+
+So when AI PCs become the next boom, I would not first look at who sold more laptops, or whose TOPS number is higher. Those are surface outcomes. What matters is who owns the layer between the PC and the cloud model.
+
+That layer includes local runtime, model router, context layer, workflow cache, private inference, and Agent execution control. These things do not sound like PCs, but they decide whether AI PCs can move from a marketing name into infrastructure enterprises are willing to buy.
+
+Because enterprises will not ultimately pay for the words "AI PC." They will pay for one thing: can the same Agent workflow run cheaper, stabler, and more controllably?
+
+If the answer is yes, AI PCs are a real boom. If the answer is no, they are just another hardware refresh narrative. So the opportunity is not in the abstract question of "who defines the PC." It is in something more specific: who can turn local compute, context, model routing, and execution cost into the default foundation for the next generation of AI workflows?
+
+That company is selling the real picks and shovels of the AI PC era.

--- a/source/_posts/ai-pc-real-opportunity.md
+++ b/source/_posts/ai-pc-real-opportunity.md
@@ -1,0 +1,127 @@
+---
+title: 当 AI PC 成为新的风口，真正的机会在哪里？
+date: 2026-05-31 15:39:37
+categories:
+  - Independent Thinking
+tags:
+  - AI PC
+  - Token
+  - Local LLM
+  - Agentic Coding
+  - Infrastructure
+  - Enterprise
+i18n_key: ai-pc-real-opportunity
+---
+
+这几个月，很多工程师还沉浸在 Agentic Coding 的兴奋里。它是真的有用：读 repo、改代码、跑测试、解释错误、做 migration、清理技术债，过去很多懒得动的活，现在终于可以动了。
+
+AI 现在有点像鸡肋：不用不行，用了看到账单又肉疼。
+
+但真正危险的不是贵，而是它越有用，大家越会用；大家越用，账单越不像工具费，越像税。这才是上一篇《Wintel 时代结束了》没说完的部分。
+
+<!-- more -->
+
+如果 PC 真的要进入 new era，接下来正确的投资方向，不是再造一个 AI app，不是再给笔记本贴一个 AI PC 标签，也不是继续卷谁的 TOPS 更高。真正值得看的问题只有一个：**谁能让企业在 Agentic Coding 变成刚需之后，把高频智能任务跑得更便宜、更稳定、更可控？**
+
+## 这个 Q 结束就会被 question
+
+Agentic Coding 现在还在兴奋期，大家看到的是它能干活。但这个 Q 结束，很多团队会开始面对另一个问题：它到底让交付变快了，还是只是把人力成本挪到了 token 成本？
+
+这不是说 Agentic Coding 没价值。恰恰相反，只有真正有价值的东西，才会把成本问题暴露得这么快。没用的工具没人天天用，好用的工具才会进入日常；一旦进入日常，它就不再是 demo、POC 或 innovation budget，而是基础设施。
+
+基础设施最怕的不是贵，而是每一次使用都不可控。今天很多 Agent 的成本结构很难看：它不是生成几行代码贵，而是在生成之前，先读十几个文件，扫半个 repo，反复问模型，失败重试，再把测试日志塞回上下文。
+
+人类工程师也会探索，也会走弯路。区别是，人类的探索成本被工资打包了，Agent 的探索成本会逐次出现在 token 账单里。所以问题不是“AI 要不要用”，不用不行；问题是：能不能让它便宜到可以一直用？
+
+## 不要从 TOPS 看 AI PC
+
+现在很多 AI PC 的讲法还停在硬件语言里：多少 TOPS、多少 NPU、多少 benchmark。这些不是没用，但不是企业真正关心的语言。企业关心的不是这台机器理论上能跑多少算力，而是这些更具体的问题：
+
+- 一个 PR review 能不能少烧一半 token？
+- 一次 code migration 能不能先在本地完成 repo 理解？
+- 一段测试失败日志能不能不再每次全量上云？
+- 一个 Agent task 能不能先用本地小模型判断难度，再决定要不要调用 frontier model？
+
+AI PC 如果成立，它卖的不是“更聪明的电脑”，而是更便宜的智能工作流。这也是为什么上一轮 PC 叙事里 Wintel 是答案，这一轮不一定。
+
+上一轮 PC 的核心问题是：能不能流畅运行 Windows 软件？下一轮 PC 的核心问题是：能不能用更低成本跑足够多的本地智能任务？这两个问题完全不同。前者看 CPU、操作系统、应用生态，后者看 local runtime、模型路由、上下文缓存、内存带宽、GPU/NPU 调度、企业策略和开发者体验。
+
+谁还在只讲 TOPS，谁就还没进入真正的问题。
+
+## 第一条线：本地智能调度层
+
+下一步最重要的投资方向，是 local model router。不是让每个 app 自己决定这次请求该用哪个模型，这件事 app 做不好。因为 app 不知道每台机器有什么硬件，不知道当前电池状态，不知道本地有什么模型，不知道企业策略允许什么数据出设备，也不知道这个任务到底值不值得上云。
+
+这应该是 OS、IDE、企业平台和模型 runtime 共同承担的能力。合理的链路应该是：简单任务走本地小模型，私有上下文走本地 RAG 或企业私有模型，中等任务走便宜模型，关键推理才走云端 frontier model，敏感任务禁止出设备或出企业边界。
+
+Microsoft 做 [Foundry Local](https://github.com/microsoft/Foundry-Local) 的意义就在这里。它不是“本机跑模型玩一下”，而是把本地模型 catalog、SDK、自动硬件加速和 OpenAI-compatible API 放到应用开发链路里。
+
+[Azure AI Foundry model router](https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-router) 也在往同一个方向走：让平台根据 quality、cost、balanced 等模式做路由。现在它更多发生在云端模型之间，但逻辑迟早会下沉到 device / private / cloud 之间。
+
+真正的机会不是“我也有一个模型列表”，而是谁能把本地、私有、云端模型变成一个可治理的成本路由系统。
+
+## 第二条线：把 repo context 做薄
+
+Agentic Coding 最贵的地方，不是写代码，而是理解代码。写一句代码不贵，找出应该改哪里很贵；生成 diff 不贵，知道这个 diff 会不会炸很贵。
+
+所以 Agentic Coding 的投资机会，不在“再包一层聊天界面”，而在 context layer。它包括本地代码索引、repo map、symbol graph、AST / call graph、测试失败到源文件的映射、日志压缩、tool result cache、conversation summary，以及上下文去重、排序、裁剪。
+
+这些东西听起来不性感，但它们才是 Agentic Coding 的成本底座。因为 repo 天然在 PC 上，IDE 状态在 PC 上，terminal 输出在 PC 上，本地构建结果在 PC 上，未提交的 diff 也在 PC 上。如果每次都把这些东西粗暴塞给云端模型，让模型重新理解一遍，那就是在重复交税。
+
+一个好的本地 context layer，应该在调用大模型之前，把 50k token 的混乱上下文压成 15k token 的有效上下文。这不是优化 prompt，而是改变成本结构。谁能让 Agent 少从零开始，谁就在直接降低 token 消耗。
+
+## 第三条线：把重复推理变成资产
+
+AI 账单里有大量浪费，本质上是重复推理。同一个 repo summary、同一个 system prompt、同一种 test failure、同一类 migration pattern、同一份 API 文档、同一个企业 policy，如果每次都重新上传、重新理解、重新付钱，企业就是在给重复劳动交税。
+
+所以 cache 会变得非常重要。不是浏览器缓存那种小优化，而是 Agent workflow 的底层资产：prompt cache、semantic cache、embedding cache、tool result cache、KV cache、failure pattern cache，都会进入基础设施层。
+
+AWS Bedrock 的 [prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) 已经把这件事讲得很直白：对长且重复的上下文做缓存，可以降低延迟和 input token 成本。但这只是开始，真正有价值的 cache 会发生在本地和工作流层，因为最稳定、最可复用、最隐私敏感的上下文，往往就在用户设备和企业环境里。
+
+一个工程师每天让 Agent 看同一个 repo，为什么每次都要从零开始？一个团队每天修同一类测试失败，为什么每次都要重新解释？一个公司每天用同一套代码规范，为什么每次都要重新塞进 prompt？Agentic Coding 要从“好用但肉疼”变成“好用且可控”，cache 是绕不开的。
+
+## 第四条线：高频低价值任务必须下云
+
+这里很容易误解。我不是说所有 AI 都要本地跑。短中期内，本地模型不需要打败 Claude、GPT 或 Gemini，它只需要吃掉足够多的高频、低中复杂度任务。
+
+比如意图识别、任务分类、日志摘要、简单代码修改、本地 embedding、文档检索、敏感内容预处理、Agent 路由前的初筛。这些任务不一定需要最强模型，但调用频率非常高，一旦全部上云，账单会很难看。
+
+这就是 AI PC 的真正企业价值。它不是替代 frontier model，而是减少不该上云的调用。过去买 PC，是买一个访问云服务的终端；接下来买 AI PC，应该是买一个能持续减少云端 token 支出的本地智能节点。
+
+这件事一旦成立，硬件采购逻辑就会变。32GB 不再只是“开 Chrome 更顺”，64GB 不再只是“开发者爽一点”，内存带宽、统一内存、SSD 本地缓存、GPU/NPU 调度，都不再只是参数。它们都会变成 token efficiency 的一部分。
+
+不是 x86 和 Arm 谁更有信仰，而是谁能用更低功耗、更低延迟、更少云端调用，把同样的 Agent workflow 跑完。
+
+## 第五条线：Agent 需要成本刹车
+
+Agent 最大的问题，不只是会犯错，而是它会很努力地犯错。普通 LLM 调用，一次输入一次输出，成本还算可估；Agent 不一样，它会规划、读文件、调用工具、失败重试、反思、再调用工具。没有边界，它可以把一个简单任务跑成一次昂贵旅行。
+
+所以真正的 Agent 平台不能只回答“能不能完成任务”，还要回答准备用多少钱完成、最多跑多少步、超过 token budget 怎么办、要不要降级模型、要不要改走本地模型、要不要停下来问人、要不要复用已有 cache。
+
+这不是传统意义上的 FinOps dashboard。dashboard 只能告诉你钱已经烧了，真正的机会在于把成本控制放进执行路径里。Agent 在行动前就应该知道预算，在行动中应该不断评估边际收益，在继续烧钱前应该有刹车。否则所谓自动化，最后就是自动交税。
+
+## 我会看什么
+
+如果 new era of PC 成立，我不会只看谁卖出更多 AI PC。那是结果，不是因。我会看四类公司。
+
+第一，local AI runtime 和模型路由层。它们把 CPU、GPU、NPU、本地模型、私有模型、云端模型统一成一个开发者不用操心的推理入口。
+
+第二，Agentic Coding 的 context layer。它们把 repo、IDE、terminal、test、log、diff 变成可复用的本地智能资产，而不是每次都重新塞给云端模型。
+
+第三，面向 Agent workflow 的 cache 和 cost-aware execution。它们不只是展示账单，而是在每一次工具调用、上下文拼接、模型路由、失败重试之前减少浪费。
+
+第四，真正能把硬件参数翻译成经济结果的 AI PC 生态。不是“这台机器有多少 TOPS”，而是“这台机器能让团队少烧多少云端 token”。
+
+反过来，我会警惕几类东西：只讲 AI PC，不讲本地 runtime；只讲 TOPS，不讲 tokens per watt；只讲 Agent 自动化，不讲成本边界；只讲大模型能力，不讲 model routing；只讲 FinOps dashboard，不介入执行链路。这些东西可能有热度，但很难回答真正的问题。
+
+## 最后
+
+所以，当 AI PC 成为新的风口，我不会先看谁多卖了几台笔记本，也不会先看谁的 TOPS 更高。那些都是表层结果。真正值得看的，是谁站在 PC 和云端模型之间那一层。
+
+这层东西包括 local runtime、model router、context layer、workflow cache、private inference、Agent execution control。它们听起来不像 PC，但它们才决定 AI PC 能不能从 marketing name 变成企业愿意买单的基础设施。
+
+因为企业最后不会为 AI PC 这三个字付钱。企业会为一件事付钱：同样的 Agent workflow，能不能更便宜、更稳定、更可控地跑完。
+
+如果答案是能，AI PC 才是真风口。如果答案是不能，它就只是又一轮硬件换机叙事。所以这轮机会不在“谁定义 PC”这么抽象的问题里，而在更具体的地方：谁能把本地算力、上下文、模型路由和执行成本，做成下一代 AI 工作流的默认底座。
+
+谁就在卖 AI PC 时代真正的铲子。

--- a/tools/check-post-style.js
+++ b/tools/check-post-style.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = process.cwd();
+const POSTS_DIR = path.join('source', '_posts');
+
+function runGit(args) {
+  try {
+    return execFileSync('git', args, {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function changedPostFiles() {
+  const files = new Set();
+  const mergeBase =
+    runGit(['merge-base', 'HEAD', 'origin/master']) ||
+    runGit(['merge-base', 'HEAD', 'master']);
+
+  if (mergeBase) {
+    for (const file of runGit(['diff', '--name-only', '--diff-filter=ACMRT', `${mergeBase}...HEAD`]).split('\n')) {
+      if (file) files.add(file);
+    }
+  }
+
+  for (const range of [['--cached'], []]) {
+    for (const file of runGit(['diff', '--name-only', '--diff-filter=ACMRT', ...range]).split('\n')) {
+      if (file) files.add(file);
+    }
+  }
+
+  for (const file of runGit(['ls-files', '--others', '--exclude-standard', POSTS_DIR]).split('\n')) {
+    if (file) files.add(file);
+  }
+
+  return [...files]
+    .filter(file => file.startsWith(`${POSTS_DIR}/`) && file.endsWith('.md'))
+    .filter(file => fs.existsSync(path.join(ROOT, file)));
+}
+
+function bodyWithoutFrontMatter(text) {
+  return text.replace(/^---\n[\s\S]*?\n---\n?/, '');
+}
+
+function isStructuralParagraph(value) {
+  const text = value.trim();
+  return (
+    text === '' ||
+    text.startsWith('#') ||
+    text.startsWith('- ') ||
+    text.startsWith('* ') ||
+    /^\d+\.\s/.test(text) ||
+    text.startsWith('>') ||
+    text.startsWith('|') ||
+    text.startsWith('<!--') ||
+    text.startsWith('```') ||
+    text.startsWith('~~~')
+  );
+}
+
+function sentenceCount(text) {
+  const cjkTerminalMarks = text.match(/[。！？]/g);
+  const latinTerminalMarks = text
+    .replace(/[。！？]/g, '')
+    .match(/[.!?]+(?=$|["'”’）)]?\s)/g);
+  return (cjkTerminalMarks ? cjkTerminalMarks.length : 0) + (latinTerminalMarks ? latinTerminalMarks.length : 0);
+}
+
+function isShortStandaloneSentence(value) {
+  const text = value.trim();
+  if (isStructuralParagraph(text)) return false;
+  if (text.includes('\n')) return false;
+  if (text.length > 120) return false;
+  if (sentenceCount(text) > 1) return false;
+  if (/[:：]\s*$/.test(text)) return false;
+  return /[.!?。！？]$/.test(text) || /[?？]$/.test(text);
+}
+
+function paragraphsWithLines(text) {
+  const paragraphs = [];
+  const lines = text.split('\n');
+  let startLine = 1;
+  let current = [];
+
+  function flush(line) {
+    if (current.length > 0) {
+      paragraphs.push({ value: current.join('\n').trim(), line: startLine });
+      current = [];
+    }
+    startLine = line + 1;
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim() === '') {
+      flush(index + 1);
+    } else {
+      if (current.length === 0) {
+        startLine = index + 1;
+      }
+      current.push(line);
+    }
+  }
+
+  flush(lines.length + 1);
+  return paragraphs;
+}
+
+function checkFragmentedParagraphs(file, text, errors) {
+  const paragraphs = paragraphsWithLines(text);
+  let run = [];
+
+  function flush() {
+    if (run.length >= 3) {
+      const line = run[0].line;
+      errors.push(`${file}:${line}: ${run.length} consecutive short one-sentence paragraphs. Merge explanatory prose, use a real list, or keep only deliberate punchlines/questions as standalone paragraphs.`);
+    }
+    run = [];
+  }
+
+  for (const paragraph of paragraphs) {
+    if (isShortStandaloneSentence(paragraph.value)) {
+      run.push(paragraph);
+    } else {
+      flush();
+    }
+  }
+  flush();
+}
+
+function main() {
+  const errors = [];
+  const files = changedPostFiles();
+
+  for (const file of files) {
+    const absolute = path.join(ROOT, file);
+    const text = bodyWithoutFrontMatter(fs.readFileSync(absolute, 'utf8'));
+    checkFragmentedParagraphs(file, text, errors);
+  }
+
+  if (errors.length > 0) {
+    console.error(`Post style check failed with ${errors.length} issue(s):`);
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Post style check passed${files.length ? ` (${files.length} changed post file(s))` : ''}.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a bilingual post titled `当 AI PC 成为新的风口，真正的机会在哪里？`, framed as the follow-up to the Wintel/new-PC thesis.

- Uses Agentic Coding as the entry point and pressure test, not as the whole topic.
- Centers the narrative on what becomes investable when AI PCs become a new market focus.
- Uses the post slug `ai-pc-real-opportunity` to match the title and avoid over-indexing on the previous token-tax framing.
- Frames the opportunity around the layer between PCs and cloud models: local runtime, model router, context layer, workflow cache, private inference, and Agent execution control.
- Reworks the ending into an explicit investment thesis: the real picks and shovels are the systems that make the same Agent workflow cheaper, stabler, and more controllable.
- Reorganized fragmented one-line paragraphs into coherent paragraphs and compact lists for better post and WeChat reading rhythm.
- Tightens `CONVENTIONS.md` so stacked explanatory one-sentence paragraphs are explicitly disallowed unless they are deliberate punchlines/questions/judgments.
- Adds `npm run check:post-style` to fail changed posts with repeated short one-sentence paragraph stacks.
- Keeps official reference links for Microsoft Foundry Local, Azure AI Foundry model router, and Amazon Bedrock prompt caching.

## Validation

- `python3 ~/.claude/skills/write-blog/fix_quotes.py source/_posts/ai-pc-real-opportunity.md`
- `python3 ~/.claude/skills/write-blog/fix_quotes.py source/_posts/ai-pc-real-opportunity.en.md`
- `npm run check:conventions`
- `npm run check:post-style`
- `npm run clean && npm run build`
- `git diff --check`

Known local warning:

- OG card generation is skipped because local Python is missing `PIL/Pillow`; Hexo generation and the build checks still pass.