### PR TITLE
Add WeChat Official Account promotion

### DIFF
--- a/themes/maupassant/_config.yml
+++ b/themes/maupassant/_config.yml
@@ -55,6 +55,11 @@ donate:
 #  btc_qr: ## Path of Bitcoin QRcode image, e.g. /img/BTCQR.png
 #  btc_key: ## Bitcoin key, e.g. 1KuK5eK2BLsqpsFVXXSBG5wbSAwZVadt6L
 #  paypal_url: ## Paypal URL, e.g. https://www.paypal.me/tufu9441
+wechat_mp:
+  enable: true ## Show WeChat Official Account promotion after each post
+  name: johnsonlee.io ## WeChat Official Account name
+  qrcode: /img/WeChatMPQR.png ## Path to QR code image
+
 post_copyright:
   enable: true ## If you want to display the copyright info after each post, please set the value to true and fill the following items on your need.
   author: johnsonlee ## Your author name, e.g. tufu9441

--- a/themes/maupassant/layout/_partial/wechat_mp.pug
+++ b/themes/maupassant/layout/_partial/wechat_mp.pug
@@ -1,0 +1,11 @@
+if theme.wechat_mp && theme.wechat_mp.enable
+  .wechat-mp
+    .wechat-mp-inner
+      .wechat-mp-text
+        .wechat-mp-title
+          i.fa.fa-weixin
+          |  关注公众号
+        .wechat-mp-name= theme.wechat_mp.name
+        .wechat-mp-desc 扫码，第一时间收到新文章推送
+      .wechat-mp-qr
+        img(src=url_for(theme.wechat_mp.qrcode), alt=theme.wechat_mp.name, onerror='this.parentElement.style.display="none"')

--- a/themes/maupassant/layout/post.pug
+++ b/themes/maupassant/layout/post.pug
@@ -60,6 +60,8 @@ block content
               != __('copyright_default_text')
       br
 
+    include _partial/wechat_mp.pug
+
     if theme.shareto == true
       script(type='text/javascript', src=url_for(theme.js) + '/share.js', async)
       a.article-share-link(data-url=page.permalink, data-id=page._id, data-qrcode=qrcode(page.permalink))= __('shareto')

--- a/themes/maupassant/source/css/style.scss
+++ b/themes/maupassant/source/css/style.scss
@@ -1989,6 +1989,45 @@ em.search-keyword {
     }
 }
 
+// ===== WeChat MP Promotion =====
+.wechat-mp {
+    margin: 2em 0;
+    padding: 1.2em 1.5em;
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-secondary);
+    border-radius: 4px;
+    .wechat-mp-inner {
+        display: flex;
+        align-items: center;
+        gap: 1.5em;
+    }
+    .wechat-mp-text {
+        flex: 1;
+    }
+    .wechat-mp-title {
+        font-size: 0.85em;
+        color: var(--text-tertiary);
+        margin-bottom: 0.4em;
+        .fa-weixin { color: #07C160; }
+    }
+    .wechat-mp-name {
+        font-size: 1.1em;
+        font-weight: bold;
+        color: var(--text-primary);
+        margin-bottom: 0.4em;
+    }
+    .wechat-mp-desc {
+        font-size: 0.85em;
+        color: var(--text-muted);
+    }
+    .wechat-mp-qr img {
+        width: 100px;
+        height: 100px;
+        display: block;
+        border-radius: 4px;
+    }
+}
+
 // ===== Gitalk Dark Mode =====
 [data-theme="dark"], [data-weather="night"] {
   .gt-container {


### PR DESCRIPTION
## Summary

Adds a WeChat Official Account promotion block to post pages.

- Adds theme config for the WeChat promotion content.
- Adds a `wechat_mp` partial and includes it in the post layout.
- Adds SCSS styling for the promotion block.

## Validation

- `git diff --check origin/master...HEAD`
- `npm run clean && npm run build`

Known local warning:

- OG card generation is skipped because local Python is missing `PIL/Pillow`; Hexo generation and the build checks still pass.