### PR TITLE
post: add Agent TDD article

### DIFF
--- a/source/_posts/agent-tdd-is-self-verification.en.md
+++ b/source/_posts/agent-tdd-is-self-verification.en.md
@@ -17,17 +17,35 @@ A few days ago I came across an experiment on Martin Fowler's site. The author g
 
 <!-- more -->
 
-## TDD Was Solving a Human Problem
+## What Problem Was TDD Originally Solving?
 
-Two things often get bundled together under TDD: tests, and a way of writing code.
+TDD targets a familiar way of building software: write a large chunk of implementation, then verify it much later. By the time a test fails, dozens of things have changed and nobody knows where the mistake came from. Bigger changes create slower feedback. Slower feedback makes people afraid to change the code. The more afraid they become, the less willing they are to refactor it.
 
-Tests are useful. They record behavior, protect against regressions, and make refactoring safer. But Red-Green-Refactor is first of all a way to help humans think. Writing the test first makes us look at the interface from the caller's side. Moving one small step at a time keeps the problem from overflowing our heads. Each green light gives us enough confidence to take the next step.
+Red-Green-Refactor cuts that long feedback chain into small pieces. Define one small behavior, watch it fail, write only enough code to make it pass, then clean up the design. Only one variable changes at a time, so failures are easy to locate. The code stays in a working state, which gives the developer enough confidence to continue.
 
-Kent Beck described TDD as a way to manage fear. Agents do not feel fear, and they do not hesitate because a problem looks too large. Given a complete requirement, an Agent is usually planning the tests and implementation together. Making it write the test file first changes the order in which text lands on disk. It does not mean the Agent went through the same thinking a human does.
+Kent Beck described TDD as a way to manage fear. That fear is concrete: fear of breaking the code, losing control, or holding a problem too large to fit in your head. Test-first also forces developers to see an interface from the caller's side before disappearing into implementation and producing an API only its author can use.
 
-It is like asking an excavator to stretch its wrists before work. The motion is fine. The machine does not have those muscles.
+**The original value of TDD was helping humans control complexity through short feedback loops. Tests are the executable assets those loops leave behind.**
 
-**The value TDD gives humans cannot be copied into an Agent with a prompt.**
+Agents do not feel fear, and they do not hesitate because a problem looks too large. Given a complete requirement, an Agent is usually planning the tests and implementation together. Making it write the test file first changes the order in which text lands on disk. It does not mean the Agent went through the same thinking a human does.
+
+Copying the workflow into an Agent Loop is like asking an excavator to stretch its wrists before work. The motion is fine. The machine does not have those muscles.
+
+## TDD Optimizes Locally; Architecture Design Sets the Direction
+
+Each TDD cycle asks two questions: what is the next failing example, and what is the smallest change that makes it pass? This is local search. It works well when the problem boundary is already clear. On a complex task where the boundary has not been drawn, it can easily confuse a correct next step with a correct direction.
+
+Imagine asking an Agent to rebuild a payment module. The first test covers a single-currency payment, the second adds a coupon, and the third adds a refund. Every step can go Red-Green, and the code keeps running. Then multi-currency, partial refunds, idempotency, and reconciliation arrive together, and it becomes obvious that the original data model was wrong. The green tests did not help. They welded the wrong structure in place.
+
+The first step of a complex task should not be the first test. It should be Architecture Design: where module boundaries sit, who owns state, how data flows, where transactions end, how failures recover, and which constraints may never be broken. These are global questions. They do not naturally emerge from a sequence of local examples.
+
+Architecture Design does not mean writing a fifty-page document before touching code. It means deciding the shape of the system first so that local search happens inside the right boundaries. **Architecture decides where to go. TDD helps each step avoid a pothole.**
+
+[Birgitta Böckeler's experiment](https://martinfowler.com/articles/exploring-gen-ai/tdd-in-the-agent-loop.html) supports this explanation. Across five batches, non-TDD solutions repeatedly took the top two spots on small and medium tasks while TDD solutions landed in the bottom two. TDD finished in the middle on the large task. Mutation scores showed no meaningful gap.
+
+After reading the traces, Opus found that Agents without TDD instructions tended to think through the data model, edge cases, contracts, and overall design before writing anything. Under TDD, they kept making locally minimal changes around the first test. The early design hardened quickly, and the Agents rarely returned for a serious Refactor.
+
+The experiment was small. Every task was greenfield, and another LLM judged quality, so it cannot prove that TDD always makes Agents worse. But it exposes the real issue: **we do not need a more obedient coding loop. We need global design first, then an Agent running inside its boundaries.**
 
 ## A Red Test Can Still Be Wrong
 
@@ -41,18 +59,6 @@ That is why I care more about mutation testing. Deliberately break the implement
 
 **What matters most is not when the test was written, but where its answer came from.**
 
-## TDD May Be Getting in the Agent's Way
-
-[Birgitta Böckeler's experiment](https://martinfowler.com/articles/exploring-gen-ai/tdd-in-the-agent-loop.html) ran five batches. In the small and medium tasks, non-TDD solutions repeatedly took the top two spots while TDD solutions landed in the bottom two. On the large task, TDD finished in the middle. Mutation scores showed no meaningful gap.
-
-After reading the execution traces, Opus suggested an explanation. Without TDD instructions, the Agent tended to think through the data model, edge cases, contracts, and overall design before writing anything. Under TDD, it kept making locally minimal changes around the first test. The early design hardened quickly, and the Agent rarely returned for the kind of serious Refactor a human would do.
-
-That is the opposite of our familiar experience. Humans use small steps to discover a design. Agents may be better at seeing the whole problem and generating a reasonably complete solution in one pass. Forcing baby steps on them may simply impose a human cognitive limit on a machine.
-
-The experiment was small. Every task was greenfield, and another LLM judged quality. It cannot prove that TDD always makes Agents worse. Cache hits also mean three times the tokens does not mean three times the bill.
-
-But it is enough to ask: if quality did not improve and token use went up, why are we treating this workflow as the default?
-
 ## Keep the Tests Outside the Agent Loop
 
 I am not arguing that we should throw away TDD. I am arguing that we should take it apart.
@@ -65,18 +71,18 @@ Examples supplied by stakeholders, regression cases from production incidents, g
 
 This is [What Caps How](https://johnsonlee.io/2026/03/10/what-caps-how.en/) applied to testing. A test should be an executable What. If the Agent defines the What and then uses its own How to satisfy it, the whole exercise becomes self-verification.
 
-## I Do Not Care How the Agent Writes It
+## Once the Boundaries Are Drawn, I Do Not Care How the Agent Writes It
 
-The faster Agents produce code, the more I need regression tests, architecture tests, static analysis, mutation testing, and benchmarks. But these should be external gates, not a process log the Agent uses to prove that it worked diligently.
+Architecture Design sets the direction. Regression tests, architecture tests, static analysis, mutation testing, and benchmarks guard the boundaries. Once those boundaries are drawn, I do not care whether the Agent writes the test or implementation first.
 
-If tests cannot kill mutations, improve the tests. If module boundaries drift, add an architecture rule. If a real sample exposes a missed edge case, put it into the regression corpus. Whether the Agent wrote the test or the implementation first does not matter to me.
+If tests cannot kill mutations, improve the tests. If module boundaries drift, add an architecture rule. If a real sample exposes a missed edge case, put it into the regression corpus.
 
 Refactoring does not have to follow every Green step either. Complexity, dependency direction, change spread, and performance regression can trigger a review directly. Fixing an observable bad result is more reliable than reminding the Agent in a prompt that "now it is time to Refactor carefully."
 
 This is the same argument I made in ["From Prompt to Harness"](https://johnsonlee.io/2026/05/15/from-prompt-to-harness.en/): telling an Agent how to work can only change the probability that it gets the answer right. A Harness is what stops the wrong answer from getting through.
 
-TDD is not obsolete. It is still a good thinking tool when humans write code, and a good collaboration model when humans write tests and Agents write the implementation.
+TDD is not obsolete. It is still a good thinking tool when humans write code, and a good collaboration model when humans write tests and Agents write the implementation. But for a complex task, the order should be Architecture Design, external verification, then Agent implementation—not an immediate dive into Red-Green-Refactor.
 
 What should disappear is the unwatched Red-Green-Refactor performance inside the Agent Loop.
 
-The next time an Agent says, "Strictly followed TDD," do not relax just yet. Ask one question: **who supplied the answers in those tests?**
+The next time an Agent says, "Strictly followed TDD," do not relax just yet. Ask one question: **who designed the architecture, and who supplied the answers in those tests?**

--- a/source/_posts/agent-tdd-is-self-verification.en.md
+++ b/source/_posts/agent-tdd-is-self-verification.en.md
@@ -4,7 +4,7 @@ date: 2026-08-13 09:23:00
 lang: en
 i18n_key: agent-tdd-is-self-verification
 categories:
-  - Independent Thinking
+  - Harness Engineering
 tags:
   - AI
   - Agentic Coding

--- a/source/_posts/agent-tdd-is-self-verification.en.md
+++ b/source/_posts/agent-tdd-is-self-verification.en.md
@@ -1,0 +1,82 @@
+---
+title: "Does an Agent Really Need TDD?"
+date: 2026-08-13 09:23:00
+lang: en
+i18n_key: agent-tdd-is-self-verification
+categories:
+  - Independent Thinking
+tags:
+  - AI
+  - Agentic Coding
+  - TDD
+  - Harness Engineering
+  - Testing
+---
+
+A few days ago I came across an experiment on Martin Fowler's site. The author gave the same tasks to Sonnet 4.6, told one group to follow TDD and let the other work however it wanted, then had Opus 4.8 judge the results blind. The result was awkward: TDD did not produce better code, but used at least three times as many tokens. My first thought was not that TDD had become obsolete. It was that we might be asking Agents to do something that looks like engineering but makes little sense: set their own exam, answer it, and declare that they passed.
+
+<!-- more -->
+
+## TDD Was Solving a Human Problem
+
+Two things often get bundled together under TDD: tests, and a way of writing code.
+
+Tests are useful. They record behavior, protect against regressions, and make refactoring safer. But Red-Green-Refactor is first of all a way to help humans think. Writing the test first makes us look at the interface from the caller's side. Moving one small step at a time keeps the problem from overflowing our heads. Each green light gives us enough confidence to take the next step.
+
+Kent Beck described TDD as a way to manage fear. Agents do not feel fear, and they do not hesitate because a problem looks too large. Given a complete requirement, an Agent is usually planning the tests and implementation together. Making it write the test file first changes the order in which text lands on disk. It does not mean the Agent went through the same thinking a human does.
+
+It is like asking an excavator to stretch its wrists before work. The motion is fine. The machine does not have those muscles.
+
+**The value TDD gives humans cannot be copied into an Agent with a prompt.**
+
+## A Red Test Can Still Be Wrong
+
+The usual argument for making an Agent show Red first is simple: if the test failed before the implementation, at least we know it is not decorative.
+
+Red only proves that the test and code disagreed. It says nothing about why. Maybe the implementation is missing. Maybe the import is broken, the fixture is wrong, or the test asserts a requirement that never existed. If the same Agent writes both test and implementation, they can share the same misunderstanding.
+
+The article includes a particularly clear example: a test called the implementation logic again to calculate the expected value, then compared the two results. Of course it went green. Watching that test fail before writing the implementation would not have moved it any closer to the real requirement.
+
+That is why I care more about mutation testing. Deliberately break the implementation and see whether the tests notice. At least that proves the net is real. But even a high mutation score only proves that tests detect changes in code. It does not prove that the expected answer is correct.
+
+**What matters most is not when the test was written, but where its answer came from.**
+
+## TDD May Be Getting in the Agent's Way
+
+[Birgitta Böckeler's experiment](https://martinfowler.com/articles/exploring-gen-ai/tdd-in-the-agent-loop.html) ran five batches. In the small and medium tasks, non-TDD solutions repeatedly took the top two spots while TDD solutions landed in the bottom two. On the large task, TDD finished in the middle. Mutation scores showed no meaningful gap.
+
+After reading the execution traces, Opus suggested an explanation. Without TDD instructions, the Agent tended to think through the data model, edge cases, contracts, and overall design before writing anything. Under TDD, it kept making locally minimal changes around the first test. The early design hardened quickly, and the Agent rarely returned for the kind of serious Refactor a human would do.
+
+That is the opposite of our familiar experience. Humans use small steps to discover a design. Agents may be better at seeing the whole problem and generating a reasonably complete solution in one pass. Forcing baby steps on them may simply impose a human cognitive limit on a machine.
+
+The experiment was small. Every task was greenfield, and another LLM judged quality. It cannot prove that TDD always makes Agents worse. Cache hits also mean three times the tokens does not mean three times the bill.
+
+But it is enough to ask: if quality did not improve and token use went up, why are we treating this workflow as the default?
+
+## Keep the Tests Outside the Agent Loop
+
+I am not arguing that we should throw away TDD. I am arguing that we should take it apart.
+
+If a human writes the test, it carries human judgment, and having the Agent implement against it is valuable. If the Agent writes a test and a human confirms that it describes the right behavior before implementation continues, that is useful too. The suspicious case is the third one: the Agent writes the test, watches it fail, adds the implementation, and watches it pass, all inside its own Loop with no outside judgment.
+
+All three look like TDD. The real difference is **whether the test and implementation came from the same source of answers**.
+
+Examples supplied by stakeholders, regression cases from production incidents, golden outputs from a legacy system, protocol schemas, and performance budgets all sit closer to ground truth. They may not look like unit tests, but each tells the Agent what it must not ship.
+
+This is [What Caps How](https://johnsonlee.io/2026/03/10/what-caps-how.en/) applied to testing. A test should be an executable What. If the Agent defines the What and then uses its own How to satisfy it, the whole exercise becomes self-verification.
+
+## I Do Not Care How the Agent Writes It
+
+The faster Agents produce code, the more I need regression tests, architecture tests, static analysis, mutation testing, and benchmarks. But these should be external gates, not a process log the Agent uses to prove that it worked diligently.
+
+If tests cannot kill mutations, improve the tests. If module boundaries drift, add an architecture rule. If a real sample exposes a missed edge case, put it into the regression corpus. Whether the Agent wrote the test or the implementation first does not matter to me.
+
+Refactoring does not have to follow every Green step either. Complexity, dependency direction, change spread, and performance regression can trigger a review directly. Fixing an observable bad result is more reliable than reminding the Agent in a prompt that "now it is time to Refactor carefully."
+
+This is the same argument I made in ["From Prompt to Harness"](https://johnsonlee.io/2026/05/15/from-prompt-to-harness.en/): telling an Agent how to work can only change the probability that it gets the answer right. A Harness is what stops the wrong answer from getting through.
+
+TDD is not obsolete. It is still a good thinking tool when humans write code, and a good collaboration model when humans write tests and Agents write the implementation.
+
+What should disappear is the unwatched Red-Green-Refactor performance inside the Agent Loop.
+
+The next time an Agent says, "Strictly followed TDD," do not relax just yet. Ask one question: **who supplied the answers in those tests?**

--- a/source/_posts/agent-tdd-is-self-verification.en.md
+++ b/source/_posts/agent-tdd-is-self-verification.en.md
@@ -9,7 +9,6 @@ tags:
   - AI
   - Agentic Coding
   - TDD
-  - Harness Engineering
   - Testing
 ---
 

--- a/source/_posts/agent-tdd-is-self-verification.md
+++ b/source/_posts/agent-tdd-is-self-verification.md
@@ -2,7 +2,7 @@
 title: Agent 真的需要 TDD 吗？
 date: 2026-08-13 09:23:00
 categories:
-  - Independent Thinking
+  - Harness Engineering
 tags:
   - AI
   - Agentic Coding

--- a/source/_posts/agent-tdd-is-self-verification.md
+++ b/source/_posts/agent-tdd-is-self-verification.md
@@ -7,7 +7,6 @@ tags:
   - AI
   - Agentic Coding
   - TDD
-  - Harness Engineering
   - Testing
 i18n_key: agent-tdd-is-self-verification
 ---

--- a/source/_posts/agent-tdd-is-self-verification.md
+++ b/source/_posts/agent-tdd-is-self-verification.md
@@ -1,0 +1,81 @@
+---
+title: Agent 真的需要 TDD 吗？
+date: 2026-08-13 09:23:00
+categories:
+  - Independent Thinking
+tags:
+  - AI
+  - Agentic Coding
+  - TDD
+  - Harness Engineering
+  - Testing
+i18n_key: agent-tdd-is-self-verification
+---
+
+前两天在 Martin Fowler 网站看到一篇文章。作者把同一批任务交给 Sonnet 4.6，一组要求严格按 TDD 做，一组随它写，再让 Opus 4.8 盲评。结果有点打脸：TDD 组没写得更好，Token 至少多烧 3 倍。看到这里，我第一反应不是 TDD 过时了，而是我们可能让 Agent 做了一件看起来很工程、其实很奇怪的事：自己出题，自己答题，再自己宣布通过。
+
+<!-- more -->
+
+## TDD 解决的本来就是人的问题
+
+TDD 有两样东西经常被混在一起：测试，和写代码的方式。
+
+测试当然有用。它记录行为，保护回归，也让重构有底气。但 Red-Green-Refactor 这套流程，本来是在帮人思考。先写测试，逼着我们从调用者的角度看接口；一步只做一点，避免脑子同时装太多东西；每亮一盏绿灯，就敢再往前走一步。
+
+Kent Beck 说 TDD 是用来管理 fear 的。Agent 没有 fear，也不会因为问题太大而不敢下手。它拿到完整需求时，通常已经在同时规划测试和实现。要求它先把测试写进文件，只是换了落盘顺序，不代表它真的经历了人写测试时那段思考。
+
+这就像要求挖掘机开工前先活动手腕。动作没错，机器没有那块肌肉。
+
+**TDD 对人的价值，不能靠一段 prompt 原样搬给 Agent。**
+
+## Red 过，不等于测试对
+
+很多人坚持让 Agent 先跑出 Red，理由也很直接：测试先失败过，至少能证明它不是摆设。
+
+可 Red 只能证明测试和代码不一致，证明不了为什么不一致。可能是实现缺了，也可能是 import 错了、fixture 坏了，甚至测试断言了一个根本不存在的需求。如果测试和实现都来自同一个 Agent，它们还会共享同一份误解。
+
+原文里就出现过一个很典型的例子：测试重新调用实现逻辑计算 expected value，再拿两边结果做比较。它当然会绿。更荒唐的是，哪怕先把这段测试写出来、亲眼看它红过，也不会让它更接近真实需求。
+
+所以我更在意 mutation testing。故意改坏实现，看看测试能不能抓到，至少能证明这张网不是画上去的。但 mutation score 再高，也只能证明测试能发现代码变化，不能证明测试里的答案是对的。
+
+**测试最重要的不是先写，而是答案从哪里来。**
+
+## TDD 反而挡住了 Agent
+
+[Birgitta Böckeler 的实验](https://martinfowler.com/articles/exploring-gen-ai/tdd-in-the-agent-loop.html)一共做了 5 个 batch。小型和中型任务里，非 TDD 实现多次排在前两名，TDD 实现落在后两名；大型任务里，TDD 只排在中间。两组的 mutation score 也没拉开差距。
+
+Opus 看完执行记录后给了一个解释：不受 TDD 限制时，Agent 往往先把数据结构、边界条件和整体设计想一遍；按 TDD 做时，它围着第一个测试不断做局部最小修改，早期设计很快被锁死，后面却没有像人一样认真回头 Refactor。
+
+这和我们熟悉的经验正好相反。人通过小步慢慢发现设计，Agent 却更擅长先看完整问题，再一次性生成一个相对完整的方案。硬逼它走 baby steps，可能是在拿人的认知限制约束机器。
+
+当然，这个实验很小，任务都是从零实现，质量还是由另一个 LLM 评的。它证明不了“Agent 做 TDD 一定更差”。而且缓存会让 3 倍 Token 不等于 3 倍账单。
+
+但已经足够问一句：质量没提升，Token 烧得更多，我们为什么默认这套流程值得保留？
+
+## 测试要放在 Agent Loop 外面
+
+我不是要扔掉 TDD，而是要把它拆开。
+
+如果测试由人来写，里面装的是人的 judgment，Agent 再去补实现，这很有价值。如果 Agent 先写测试，人确认它测的是正确行为，再让 Agent 继续，也有价值。真正可疑的是第三种：Agent 在自己的 Loop 里写测试、看它失败、补实现、看它通过，全程没有外部判断。
+
+三种做法看起来都叫 TDD，差别不在谁先写，而在**测试和实现是不是来自同一个答案源**。
+
+需求方给出的 example、线上事故留下的 regression case、旧系统跑出来的 golden output、协议 schema、性能 budget，这些东西才接近 ground truth。它们不一定长得像 unit test，但都在告诉 Agent 什么结果不能交。
+
+这是 [What Caps How](https://johnsonlee.io/2026/03/10/what-caps-how/) 在测试里的版本。测试应该是可执行的 What。What 也让 Agent 自己定义，接下来无论 How 跑得多勤快，都只是在完成一次自证。
+
+## 我不关心 Agent 怎么写
+
+Agent 产出越快，我越需要 regression test、architecture test、static analysis、mutation testing 和 benchmark。只是这些东西应该成为外部 gate，而不是 Agent 用来证明自己认真工作的过程记录。
+
+测试杀不掉 mutation，就补测试；模块边界开始漂移，就加 architecture rule；真实样本漏了，就把它放进 regression corpus。至于 Agent 是先写测试还是先写实现，我不关心。
+
+Refactor 也不必绑在每次 Green 后面。复杂度、依赖方向、一次改动碰了多少文件、性能有没有退化，都可以直接触发 review。对着坏结果修，比在 prompt 里提醒它“现在该认真 Refactor 了”靠谱。
+
+这和我在[《从 Prompt 到 Harness》](https://johnsonlee.io/2026/05/15/from-prompt-to-harness/)里的判断一样：告诉 Agent 应该怎么做，只能改变它做对的概率；能把错误挡住的，才叫 Harness。
+
+TDD 没过时。人写代码时，它还是很好的思考工具；人写测试、Agent 写实现时，它也是很好的协作方式。
+
+该停掉的，是 Agent 在 Loop 里那场无人观看的 Red-Green-Refactor。
+
+下次 Agent 告诉你“已严格遵循 TDD”，先别急着放心。问一句：**测试里的答案，是谁给的？**

--- a/source/_posts/agent-tdd-is-self-verification.md
+++ b/source/_posts/agent-tdd-is-self-verification.md
@@ -16,17 +16,35 @@ i18n_key: agent-tdd-is-self-verification
 
 <!-- more -->
 
-## TDD 解决的本来就是人的问题
+## TDD 当初解决的是什么？
 
-TDD 有两样东西经常被混在一起：测试，和写代码的方式。
+TDD 针对的典型开发方式，是先写一大段实现，过很久才验证。等测试失败时，中间已经改了几十处，没人知道错在哪。改动越大，反馈越慢；反馈越慢，人越怕改；越怕改，代码越不敢重构。
 
-测试当然有用。它记录行为，保护回归，也让重构有底气。但 Red-Green-Refactor 这套流程，本来是在帮人思考。先写测试，逼着我们从调用者的角度看接口；一步只做一点，避免脑子同时装太多东西；每亮一盏绿灯，就敢再往前走一步。
+Red-Green-Refactor 把这个长反馈链切碎。先定义一个很小的行为，看它失败，只写够让它通过的代码，再清理设计。每次只改变一个变量，出了问题很容易定位；代码一直处于可工作状态，人也敢继续往前走。
 
-Kent Beck 说 TDD 是用来管理 fear 的。Agent 没有 fear，也不会因为问题太大而不敢下手。它拿到完整需求时，通常已经在同时规划测试和实现。要求它先把测试写进文件，只是换了落盘顺序，不代表它真的经历了人写测试时那段思考。
+Kent Beck 说 TDD 是用来管理 fear 的。这个 fear 很具体：怕改坏，怕失控，怕一个问题大到脑子装不下。Test-first 还会逼着人先从调用者看接口，不至于一头扎进实现，写出一个只有自己会用的 API。
 
-这就像要求挖掘机开工前先活动手腕。动作没错，机器没有那块肌肉。
+**TDD 当初解决的核心，是让人用短反馈控制复杂度；测试是这套反馈机制留下的可执行资产。**
 
-**TDD 对人的价值，不能靠一段 prompt 原样搬给 Agent。**
+Agent 没有 fear，也不会因为问题太大而不敢下手。它拿到完整需求时，通常已经在同时规划测试和实现。要求它先把测试写进文件，只是换了落盘顺序，不代表它经历了人写测试时那段思考。
+
+把这套流程原样搬进 Agent Loop，就像要求挖掘机开工前先活动手腕。动作没错，机器没有那块肌肉。
+
+## TDD 优化局部，Architecture Design 决定全局
+
+TDD 每一轮只问两个问题：下一个失败用例是什么？让它通过的最小改动是什么？这是一种局部搜索。问题边界已经清楚时，它很好用；复杂任务的边界还没画出来时，它很容易把“下一步正确”误当成“方向正确”。
+
+想象让 Agent 重写一个支付模块。第一个测试是单币种付款，第二个是优惠券，第三个是退款。每一步都可以 Red-Green，代码也一直能跑。等多币种、部分退款、幂等、对账一起进来，才发现最开始的数据模型就错了。前面那些绿灯没有帮忙，反而把错误结构焊得更牢。
+
+复杂任务的第一步不该是写第一个 test，而是做 Architecture Design：模块边界怎么划，状态归谁，数据往哪流，事务在哪里结束，失败怎么恢复，哪些约束不能破。这些都是全局问题，没法从一个个局部用例里自然长出来。
+
+Architecture Design 也不是先写一份几十页的大文档。它只是要求动手前先把系统的形状想清楚，让后面的局部搜索在正确边界里发生。**Architecture 决定往哪走，TDD 只负责每一步别踩空。**
+
+[Birgitta Böckeler 的实验](https://martinfowler.com/articles/exploring-gen-ai/tdd-in-the-agent-loop.html)正好印证了这一点。5 个 batch 里，非 TDD 实现在小型和中型任务中多次排在前两名，TDD 实现落在后两名；大型任务里，TDD 也只排在中间。两组的 mutation score 没拉开差距。
+
+Opus 看完执行记录后发现，不受 TDD 限制时，Agent 往往先把数据结构、边界条件和整体设计想一遍；按 TDD 做时，它围着第一个测试不断做局部最小修改，早期设计很快被锁死，后面又没有认真回头 Refactor。
+
+实验很小，任务都是从零实现，质量还是另一个 LLM 评的，证明不了“TDD 一定让 Agent 变差”。但它把真正的问题露了出来：**我们需要的不是一个更守规矩的 coding loop，而是先有全局设计，再让 Agent 在边界里跑。**
 
 ## Red 过，不等于测试对
 
@@ -40,18 +58,6 @@ Kent Beck 说 TDD 是用来管理 fear 的。Agent 没有 fear，也不会因为
 
 **测试最重要的不是先写，而是答案从哪里来。**
 
-## TDD 反而挡住了 Agent
-
-[Birgitta Böckeler 的实验](https://martinfowler.com/articles/exploring-gen-ai/tdd-in-the-agent-loop.html)一共做了 5 个 batch。小型和中型任务里，非 TDD 实现多次排在前两名，TDD 实现落在后两名；大型任务里，TDD 只排在中间。两组的 mutation score 也没拉开差距。
-
-Opus 看完执行记录后给了一个解释：不受 TDD 限制时，Agent 往往先把数据结构、边界条件和整体设计想一遍；按 TDD 做时，它围着第一个测试不断做局部最小修改，早期设计很快被锁死，后面却没有像人一样认真回头 Refactor。
-
-这和我们熟悉的经验正好相反。人通过小步慢慢发现设计，Agent 却更擅长先看完整问题，再一次性生成一个相对完整的方案。硬逼它走 baby steps，可能是在拿人的认知限制约束机器。
-
-当然，这个实验很小，任务都是从零实现，质量还是由另一个 LLM 评的。它证明不了“Agent 做 TDD 一定更差”。而且缓存会让 3 倍 Token 不等于 3 倍账单。
-
-但已经足够问一句：质量没提升，Token 烧得更多，我们为什么默认这套流程值得保留？
-
 ## 测试要放在 Agent Loop 外面
 
 我不是要扔掉 TDD，而是要把它拆开。
@@ -64,18 +70,18 @@ Opus 看完执行记录后给了一个解释：不受 TDD 限制时，Agent 往�
 
 这是 [What Caps How](https://johnsonlee.io/2026/03/10/what-caps-how/) 在测试里的版本。测试应该是可执行的 What。What 也让 Agent 自己定义，接下来无论 How 跑得多勤快，都只是在完成一次自证。
 
-## 我不关心 Agent 怎么写
+## 边界画完，我不关心 Agent 怎么写
 
-Agent 产出越快，我越需要 regression test、architecture test、static analysis、mutation testing 和 benchmark。只是这些东西应该成为外部 gate，而不是 Agent 用来证明自己认真工作的过程记录。
+Architecture Design 定方向，regression test、architecture test、static analysis、mutation testing 和 benchmark 守边界。边界画完以后，Agent 先写测试还是先写实现，我不关心。
 
-测试杀不掉 mutation，就补测试；模块边界开始漂移，就加 architecture rule；真实样本漏了，就把它放进 regression corpus。至于 Agent 是先写测试还是先写实现，我不关心。
+测试杀不掉 mutation，就补测试；模块边界开始漂移，就加 architecture rule；真实样本漏了，就把它放进 regression corpus。
 
 Refactor 也不必绑在每次 Green 后面。复杂度、依赖方向、一次改动碰了多少文件、性能有没有退化，都可以直接触发 review。对着坏结果修，比在 prompt 里提醒它“现在该认真 Refactor 了”靠谱。
 
 这和我在[《从 Prompt 到 Harness》](https://johnsonlee.io/2026/05/15/from-prompt-to-harness/)里的判断一样：告诉 Agent 应该怎么做，只能改变它做对的概率；能把错误挡住的，才叫 Harness。
 
-TDD 没过时。人写代码时，它还是很好的思考工具；人写测试、Agent 写实现时，它也是很好的协作方式。
+TDD 没过时。人写代码时，它还是很好的思考工具；人写测试、Agent 写实现时，它也是很好的协作方式。只是面对复杂任务，顺序应该变成 Architecture Design、外部验证、Agent 实现，而不是一上来就钻进 Red-Green-Refactor。
 
 该停掉的，是 Agent 在 Loop 里那场无人观看的 Red-Green-Refactor。
 
-下次 Agent 告诉你“已严格遵循 TDD”，先别急着放心。问一句：**测试里的答案，是谁给的？**
+下次 Agent 告诉你“已严格遵循 TDD”，先别急着放心。问一句：**Architecture 是谁设计的，测试里的答案又是谁给的？**


### PR DESCRIPTION
## What changed

- 新增中文文章《Agent 真的需要 TDD 吗？》
- 新增对应英文版 `Does an Agent Really Need TDD?`
- 两版共享 `i18n_key`、发布时间、分类和标签，并在相同语义边界设置 excerpt
- 补充 TDD 最初解决的人类反馈回路与修改恐惧问题
- 明确区分 TDD 的局部搜索与 Architecture Design 的全局判断

## Why

文章以 Birgitta Böckeler 在 Martin Fowler 网站发布的 Agent Loop TDD 实验为切口，讨论 TDD 中哪些价值属于人类认知过程，哪些应该沉淀为 Agent Loop 外部的可执行验证。

核心判断是：TDD 围绕下一个失败用例寻找局部解，适合在边界明确后推进实现；复杂任务必须先做 Architecture Design，确定模块边界、状态归属、数据流和失败模型，再让 Agent 在这些边界内运行。

## Impact

发布一篇符合博客既有口吻和双语 convention 的新文章，不修改站点代码或配置。

## Validation

- `node tools/check-post-style.js`
- `node tools/check-conventions.js`
- `node tools/check-quotes.js`
- `git diff --check`